### PR TITLE
setting redis cache segment name to session to stop issue with escape…

### DIFF
--- a/packages/webapp/src/plugins/session.js
+++ b/packages/webapp/src/plugins/session.js
@@ -11,7 +11,8 @@ const session = {
     maxCookieSize: 0,
     cache: {
       cache: 'redis_cache',
-      expiresIn: 24 * 60 * 60 * 1000
+      expiresIn: 24 * 60 * 60 * 1000,
+      segment: 'session'
     }
   }
 }


### PR DESCRIPTION
…d characters on redis commander