### PR TITLE
Dynamically setting isSecure flag for session cookie to resolve safar…

### DIFF
--- a/packages/webapp/README.md
+++ b/packages/webapp/README.md
@@ -23,6 +23,7 @@ warning: other service dependencies will be missing, install and run from root o
 | SESSION_COOKIE_PASSWORD | Password for the session cookie | N |
 | UPLOAD_PROCESSING_TIMEOUT_MILLIS | Upload processing timeout in milliseconds (defaults to 30000) | N |
 | AZURE_FUNCTION_APP_URL | API URL for funtion app | Y |
+| COOKIE_IS_SECURE | Sets isSecure flag for session cookie, set to true if site is SSL or false if not | N |
 
 #### Setting the SIGNALR_URL environment variable
 

--- a/packages/webapp/src/plugins/__tests__/session.spec.js
+++ b/packages/webapp/src/plugins/__tests__/session.spec.js
@@ -1,0 +1,39 @@
+describe('session', () => {
+  it('Should return normal session object', done => {
+    jest.isolateModules(async () => {
+      try {
+        const session = require('../session')
+        expect(session.default.options).not.toBeUndefined()
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  })
+  it('Should return session object with cookie isSecure as true if environment variable set to true', done => {
+    jest.isolateModules(async () => {
+      try {
+        process.env.COOKIE_IS_SECURE = 'true'
+        const session = require('../session')
+        expect(session.default.options).not.toBeUndefined()
+        expect(session.default.options.cookieOptions.isSecure).toEqual(true)
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  })
+  it('Should return session object with cookie isSecure as false if environment variable set to false', done => {
+    jest.isolateModules(async () => {
+      try {
+        process.env.COOKIE_IS_SECURE = 'false'
+        const session = require('../session')
+        expect(session.default.options).not.toBeUndefined()
+        expect(session.default.options.cookieOptions.isSecure).toEqual(false)
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  })
+})

--- a/packages/webapp/src/plugins/session.js
+++ b/packages/webapp/src/plugins/session.js
@@ -6,7 +6,7 @@ const session = {
   options: {
     cookieOptions: {
       password: SESSION_COOKIE_PASSWORD,
-      isSecure: true
+      isSecure: process.env.COOKIE_IS_SECURE ? JSON.parse(process.env.COOKIE_IS_SECURE) : false
     },
     maxCookieSize: 0,
     cache: {


### PR DESCRIPTION
…i bug

TO NOTE: will require IS_SECURE_COOKIE environment variable to be added to remote environments. Locally it will default to false for development, so does not need developer input locally.

https://eaflood.atlassian.net/browse/BNGP-1671