### PR TITLE
Feature/bngp 1922

### DIFF
--- a/packages/webapp/src/__mocks__/on-pre-handler.js
+++ b/packages/webapp/src/__mocks__/on-pre-handler.js
@@ -1,0 +1,18 @@
+import application from '../../src/__mock-data__/test-application.js'
+
+// Adds prehandler to server that loads session with mock application data or sessionData object provided from test
+const onPreHandler = (sessionData) => {
+  return {
+    plugin: {
+      name: 'on-pre-handler',
+      register: (server, _options) => {
+        server.ext('onPreHandler', function (request, h) {
+          request.yar._store = sessionData || JSON.parse(application.dataString)
+          return h.continue
+        })
+      }
+    }
+  }
+}
+
+export default onPreHandler

--- a/packages/webapp/src/__mocks__/server-options.js
+++ b/packages/webapp/src/__mocks__/server-options.js
@@ -1,4 +1,4 @@
-import { Engine as CatboxMemory } from '@hapi/catbox-memory'
+import { Engine } from '@hapi/catbox-memory'
 
 // use catbox-memory cache strategy for testing
 const serverOptions = {
@@ -6,7 +6,7 @@ const serverOptions = {
     {
       name: 'redis_cache',
       provider: {
-        constructor: CatboxMemory
+        constructor: Engine
       }
     }
   ]

--- a/packages/webapp/src/plugins/on-post-handler.js
+++ b/packages/webapp/src/plugins/on-post-handler.js
@@ -5,10 +5,13 @@ const onPostHandler = {
     name: 'on-post-handler',
     register: (server, _options) => {
       server.ext('onPostHandler', function (request, h) {
-        // If referer was a check route then set the session referer
-        // Route then decides whether to redirect to referer or not
-        if (request.method === 'get' && request.response.variety === 'view') {
+        // filter out everything but view gets
+        if (request.response.variety === 'view' && request.method === 'get') {
+          // if getting a view then set headers to stop client caching
+          request.response.headers['cache-control'] = 'no-cache, no-store, must-revalidate'
           if (request.headers.referer) {
+            // If referer was a check route then set the session referer
+            // Route then decides whether to redirect to referer or not
             const setReferer = constants.setReferer.find(item => request.headers.referer.indexOf(item) > -1)
             const clearReferer = constants.clearReferer.find(item => request.headers.referer.indexOf(item) > -1)
             if (setReferer) {

--- a/packages/webapp/src/routes/__tests__/helpers/server.js
+++ b/packages/webapp/src/routes/__tests__/helpers/server.js
@@ -6,6 +6,7 @@ import streamToPromise from 'stream-to-promise'
 import { isUploadComplete, receiveMessages } from '@defra/bng-azure-storage-test-utils'
 import { CoordinateSystemValidationError, ThreatScreeningError, ValidationError, uploadGeospatialLandBoundaryErrorCodes } from '@defra/bng-errors-lib'
 import constants from '../../../utils/constants.js'
+import onPreHandler from '../../../__mocks__/on-pre-handler.js'
 
 const startServer = async (options) => {
   const server = await createServer(options)
@@ -118,7 +119,8 @@ const uploadFile = async (uploadConfig) => {
   return response
 }
 
-const submitGetRequest = async (options, expectedResponseCode = 200) => {
+const submitGetRequest = async (options, expectedResponseCode = 200, sessionData) => {
+  await addOnPrehandler(sessionData)
   options.method = 'GET'
   return submitRequest(options, expectedResponseCode)
 }
@@ -132,6 +134,11 @@ const submitRequest = async (options, expectedResponseCode) => {
   const response = await getServer().inject(options)
   expect(response.statusCode).toBe(expectedResponseCode)
   return response
+}
+
+const addOnPrehandler = async (sessionData) => {
+  // Add session injection prehandler
+  await getServer().register(onPreHandler(sessionData))
 }
 
 export { startServer, submitGetRequest, submitPostRequest, uploadFile }

--- a/packages/webapp/src/routes/__tests__/land/add-grid-reference.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/add-grid-reference.spec.js
@@ -10,6 +10,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     let postOptions

--- a/packages/webapp/src/routes/__tests__/land/add-hectares.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/add-hectares.spec.js
@@ -7,6 +7,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     let postOptions

--- a/packages/webapp/src/routes/__tests__/land/add-landowners.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/add-landowners.spec.js
@@ -8,6 +8,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     let postOptions

--- a/packages/webapp/src/routes/__tests__/land/add-legal-agreement-parties.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/add-legal-agreement-parties.spec.js
@@ -9,6 +9,10 @@ describe(url, () => {
       const response = await submitGetRequest({ url })
       expect(response.statusCode).toBe(200)
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
     it(`should render the ${url.substring(1)} view with undefined other party`, async () => {
       jest.isolateModules(async () => {
         let viewResult, contextResult

--- a/packages/webapp/src/routes/__tests__/land/check-and-submit.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-and-submit.spec.js
@@ -1,6 +1,7 @@
 import applicationSession from '../../../__mocks__/application-session.js'
 import checkAndSubmit from '../../../routes/land/check-and-submit.js'
 import constants from '../../../utils/constants.js'
+import { submitGetRequest } from '../helpers/server.js'
 const url = constants.routes.CHECK_AND_SUBMIT
 jest.mock('../../../utils/http.js')
 
@@ -45,6 +46,10 @@ describe(url, () => {
           done(err)
         }
       })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
     })
   })
 

--- a/packages/webapp/src/routes/__tests__/land/check-geospatial-file-spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-geospatial-file-spec.js
@@ -7,6 +7,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     jest.mock('@defra/bng-connectors-lib')

--- a/packages/webapp/src/routes/__tests__/land/check-habitat-baseline.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-habitat-baseline.spec.js
@@ -1,11 +1,18 @@
 import constants from '../../../utils/constants.js'
 import checkHabitatBaseline from '../../land/check-habitat-baseline.js'
 import applicationSession from '../../../__mocks__/application-session.js'
-import { submitPostRequest } from '../helpers/server.js'
+import { submitGetRequest, submitPostRequest } from '../helpers/server.js'
 const url = constants.routes.CHECK_HABITAT_BASELINE
 
 describe(url, () => {
   describe('GET', () => {
+    it(`should render the ${url.substring(1)} view`, async () => {
+      await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
     it(`should render the ${url.substring(1)} view`, async () => {
       const session = applicationSession()
       const getHandler = checkHabitatBaseline[0].handler
@@ -20,6 +27,10 @@ describe(url, () => {
       expect(viewArgs[0]).toEqual(constants.views.CHECK_HABITAT_BASELINE)
       expect(viewArgs[1].habitatTypeAndCondition.length).toEqual(3)
       expect(viewArgs[1].habitatTypeAndCondition).toEqual(JSON.parse('[{"type":"Habitat","unitKey":"Area (hectares)","unit":"Area (ha)","header":"Broad habitat","description":"Habitat type","total":20.001,"items":[{"header":"Cropland","description":"Arable field margins tussocky","condition":"Condition Assessment N/A","amount":20.001}]},{"type":"Hedgerow","unitKey":"Length (km)","unit":"Length (km)","description":"Hedgerow type","total":40,"items":[{"description":"Native Species-rich native hedgerow with trees - associated with bank or ditch","condition":"Poor","amount":20},{"description":"Native hedgerow with trees - associated with bank or ditch","condition":"Poor","amount":20}]},{"type":"River","unitKey":"Length (km)","unit":"Length (km)","description":"Watercourse type","total":40,"items":[{"description":"Other Rivers and Streams","condition":"Fairly Poor","amount":20},{"description":"Priority Habitat","condition":"Poor","amount":20}]}]'))
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
     })
   })
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/check-habitat-created.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-habitat-created.spec.js
@@ -1,11 +1,18 @@
 import constants from '../../../utils/constants.js'
 import checkHabitatCreated from '../../land/check-habitat-created.js'
 import applicationSession from '../../../__mocks__/application-session.js'
-import { submitPostRequest } from '../helpers/server.js'
+import { submitGetRequest, submitPostRequest } from '../helpers/server.js'
 const url = constants.routes.CHECK_HABITAT_CREATED
 
 describe(url, () => {
   describe('GET', () => {
+    it(`should render the ${url.substring(1)} view`, async () => {
+      await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
     it(`should render the ${url.substring(1)} view`, async () => {
       const session = applicationSession()
       const getHandler = checkHabitatCreated[0].handler

--- a/packages/webapp/src/routes/__tests__/land/check-land-boundary-details.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-land-boundary-details.spec.js
@@ -7,6 +7,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     it('should flow to register task list', done => {

--- a/packages/webapp/src/routes/__tests__/land/check-land-boundary-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-land-boundary-file.spec.js
@@ -11,6 +11,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/check-legal-agreement-details.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-legal-agreement-details.spec.js
@@ -1,6 +1,7 @@
 import constants from '../../../utils/constants.js'
+import { submitGetRequest } from '../helpers/server.js'
 
-const url = constants.views.CHECK_LEGAL_AGREEMENT_DETAILS
+const url = constants.routes.CHECK_LEGAL_AGREEMENT_DETAILS
 const mockDataPath = 'packages/webapp/src/__mock-data__/uploads/legal-agreements'
 
 describe('Land boundary upload controller tests', () => {
@@ -24,6 +25,13 @@ describe('Land boundary upload controller tests', () => {
     })
   })
   describe('GET', () => {
+    it(`should render the ${url.substring(1)} view`, async () => {
+      await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
     it(`should render the ${url.substring(1)} view`, done => {
       jest.isolateModules(async () => {
         try {

--- a/packages/webapp/src/routes/__tests__/land/check-legal-agreement-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-legal-agreement-file.spec.js
@@ -9,6 +9,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/check-management-monitoring-details-spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-management-monitoring-details-spec.js
@@ -1,5 +1,5 @@
 import constants from '../../../utils/constants.js'
-import { submitPostRequest } from '../helpers/server'
+import { submitGetRequest, submitPostRequest } from '../helpers/server'
 
 const url = constants.routes.CHECK_MANAGEMENT_MONITORING_DETAILS
 const mockDataPath = 'packages/webapp/src/__mock-data__/uploads/legal-agreements'
@@ -12,6 +12,13 @@ describe(url, () => {
     redisMap.set(constants.redisKeys.MANAGEMENT_MONITORING_START_DATE_KEY, '2023-03-11T00:00:00.000Z')
   })
   describe('GET', () => {
+    it(`should render the ${url.substring(1)} view`, async () => {
+      await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
     it(`should render the ${url.substring(1)} view`, async () => {
       jest.isolateModules(async () => {
         let viewResult, contextResult

--- a/packages/webapp/src/routes/__tests__/land/check-management-plan-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-management-plan-file.spec.js
@@ -11,6 +11,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/check-metric-details.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-metric-details.spec.js
@@ -1,10 +1,18 @@
 import constants from '../../../utils/constants.js'
 import checkMetricDetails from '../../land/check-metric-details.js'
 import applicationSession from '../../../__mocks__/application-session.js'
+import { submitGetRequest } from '../helpers/server.js'
 const url = constants.routes.CHECK_METRIC_DETAILS
 
 describe(url, () => {
   describe('GET', () => {
+    it(`should render the ${url.substring(1)} view`, async () => {
+      await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
     it(`should render the ${url.substring(1)} view`, async () => {
       const session = applicationSession()
       const getHandler = checkMetricDetails[0].handler

--- a/packages/webapp/src/routes/__tests__/land/check-metric-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-metric-file.spec.js
@@ -11,6 +11,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/check-ownership-details.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-ownership-details.spec.js
@@ -1,10 +1,17 @@
 import constants from '../../../utils/constants.js'
-import { submitPostRequest } from '../helpers/server.js'
+import { submitGetRequest, submitPostRequest } from '../helpers/server.js'
 const url = constants.routes.CHECK_OWNERSHIP_DETAILS
 const mockDataPath = 'packages/webapp/src/__mock-data__/uploads/legal-agreements'
 
 describe(url, () => {
   describe('GET', () => {
+    it(`should render the ${url.substring(1)} view`, async () => {
+      await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
     it(`should render the ${url.substring(1)} view`, async () => {
       jest.isolateModules(async () => {
         let viewResult, contextResult

--- a/packages/webapp/src/routes/__tests__/land/check-ownership-proof-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-ownership-proof-file.spec.js
@@ -9,6 +9,13 @@ jest.mock('../../../utils/azure-storage.js')
 describe(url, () => {
   describe('GET', () => {
     it(`should render the ${url.substring(1)} view`, async () => {
+      await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
+    it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({
         url,
         headers: {

--- a/packages/webapp/src/routes/__tests__/land/choose-land-boundary-upload-option.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/choose-land-boundary-upload-option.spec.js
@@ -7,6 +7,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     let postOptions

--- a/packages/webapp/src/routes/__tests__/land/download-geospatial-land-boundary-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/download-geospatial-land-boundary-file.spec.js
@@ -1,10 +1,11 @@
 import { submitGetRequest } from '../helpers/server.js'
 import { promises as fs } from 'fs'
-const url = '/land/download-geospatial-land-boundary-file'
+import constants from '../../../utils/constants.js'
+import application from '../../../__mock-data__/test-application.js'
+const url = constants.routes.DOWNLOAD_GEOSPATIAL_LAND_BOUNDARY
 const mockDataPath = 'packages/webapp/src/__mock-data__/uploads/legal-agreements'
 jest.mock('../../../utils/azure-signalr.js')
 jest.mock('@defra/bng-connectors-lib')
-jest.mock('path')
 
 describe(url, () => {
   describe('GET', () => {
@@ -17,14 +18,13 @@ describe(url, () => {
           resolve(file)
         })
       })
-
-      // Mock the path.basename. //TODO better to inject the session yar values, but unsure how yet.
-      const path = require('path')
-      path.basename.mockImplementation(() => {
-        return 'legal-agreement.pdf'
-      })
-
-      await submitGetRequest({ url })
+      const sessionData = JSON.parse(application.dataString)
+      sessionData[constants.redisKeys.GEOSPATIAL_UPLOAD_LOCATION] = './test-location/dummy-file.doc'
+      await submitGetRequest({ url }, 200, sessionData)
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
     })
   })
 })

--- a/packages/webapp/src/routes/__tests__/land/download-land-boundary-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/download-land-boundary-file.spec.js
@@ -1,10 +1,10 @@
 import { submitGetRequest } from '../helpers/server.js'
 import { promises as fs } from 'fs'
-const url = '/land/download-land-boundary-file'
+import constants from '../../../utils/constants.js'
+const url = constants.routes.DOWNLOAD_LAND_BOUNDARY
 const mockDataPath = 'packages/webapp/src/__mock-data__/uploads/legal-agreements'
 jest.mock('../../../utils/azure-signalr.js')
 jest.mock('@defra/bng-connectors-lib')
-jest.mock('path')
 
 describe(url, () => {
   describe('GET', () => {
@@ -17,14 +17,11 @@ describe(url, () => {
           resolve(file)
         })
       })
-
-      // Mock the path.basename. //TODO better to inject the session yar values, but unsure how yet.
-      const path = require('path')
-      path.basename.mockImplementation(() => {
-        return 'legal-agreement.pdf'
-      })
-
       await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
     })
   })
 })

--- a/packages/webapp/src/routes/__tests__/land/download-land-ownership-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/download-land-ownership-file.spec.js
@@ -1,10 +1,10 @@
 import { submitGetRequest } from '../helpers/server.js'
 import { promises as fs } from 'fs'
-const url = '/land/download-land-ownership-file'
+import constants from '../../../utils/constants.js'
+const url = constants.routes.DOWNLOAD_LAND_OWNERSHIP
 const mockDataPath = 'packages/webapp/src/__mock-data__/uploads/legal-agreements'
 jest.mock('../../../utils/azure-signalr.js')
 jest.mock('@defra/bng-connectors-lib')
-jest.mock('path')
 
 describe(url, () => {
   describe('GET', () => {
@@ -17,14 +17,11 @@ describe(url, () => {
           resolve(file)
         })
       })
-
-      // Mock the path.basename. //TODO better to inject the session yar values, but unsure how yet.
-      const path = require('path')
-      path.basename.mockImplementation(() => {
-        return 'legal-agreement.pdf'
-      })
-
       await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
     })
   })
 })

--- a/packages/webapp/src/routes/__tests__/land/download-legal-agreement-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/download-legal-agreement-file.spec.js
@@ -1,10 +1,10 @@
 import { submitGetRequest } from '../helpers/server.js'
 import { promises as fs } from 'fs'
-const url = '/land/download-legal-agreement-file'
+import constants from '../../../utils/constants.js'
+const url = constants.routes.DOWNLOAD_LEGAL_AGREEMENT
 const mockDataPath = 'packages/webapp/src/__mock-data__/uploads/legal-agreements'
 jest.mock('../../../utils/azure-signalr.js')
 jest.mock('@defra/bng-connectors-lib')
-jest.mock('path')
 
 describe(url, () => {
   describe('GET', () => {
@@ -17,14 +17,11 @@ describe(url, () => {
           resolve(file)
         })
       })
-
-      // Mock the path.basename. //TODO better to inject the session yar values, but unsure how yet.
-      const path = require('path')
-      path.basename.mockImplementation(() => {
-        return 'legal-agreement.pdf'
-      })
-
       await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
     })
   })
 })

--- a/packages/webapp/src/routes/__tests__/land/download-management-plan-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/download-management-plan-file.spec.js
@@ -1,10 +1,10 @@
 import { submitGetRequest } from '../helpers/server.js'
 import { promises as fs } from 'fs'
-const url = '/land/download-management-plan-file'
+import constants from '../../../utils/constants.js'
+const url = constants.routes.DOWNLOAD_MANAGEMENT_PLAN
 const mockDataPath = 'packages/webapp/src/__mock-data__/uploads/legal-agreements'
 jest.mock('../../../utils/azure-signalr.js')
 jest.mock('@defra/bng-connectors-lib')
-jest.mock('path')
 
 describe(url, () => {
   describe('GET', () => {
@@ -18,13 +18,11 @@ describe(url, () => {
         })
       })
 
-      // Mock the path.basename. //TODO better to inject the session yar values, but unsure how yet.
-      const path = require('path')
-      path.basename.mockImplementation(() => {
-        return 'legal-agreement.pdf'
-      })
-
       await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
     })
   })
 })

--- a/packages/webapp/src/routes/__tests__/land/download-metric-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/download-metric-file.spec.js
@@ -1,10 +1,10 @@
 import { submitGetRequest } from '../helpers/server.js'
 import { promises as fs } from 'fs'
-const url = '/land/download-metric-file'
+import constants from '../../../utils/constants.js'
+const url = constants.routes.DOWNLOAD_METRIC_FILE
 const mockDataPath = 'packages/webapp/src/__mock-data__/uploads/legal-agreements'
 jest.mock('../../../utils/azure-signalr.js')
 jest.mock('@defra/bng-connectors-lib')
-jest.mock('path')
 
 describe(url, () => {
   describe('GET', () => {
@@ -17,14 +17,11 @@ describe(url, () => {
           resolve(file)
         })
       })
-
-      // Mock the path.basename. //TODO better to inject the session yar values, but unsure how yet.
-      const path = require('path')
-      path.basename.mockImplementation(() => {
-        return 'legal-agreement.pdf'
-      })
-
       await submitGetRequest({ url })
     })
+  })
+  it('should redirect to Start page if no data applicant data is available in session', async () => {
+    const response = await submitGetRequest({ url }, 302, {})
+    expect(response.headers.location).toEqual(constants.routes.START)
   })
 })

--- a/packages/webapp/src/routes/__tests__/land/habitat-works-start-date.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/habitat-works-start-date.spec.js
@@ -8,6 +8,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     let postOptions

--- a/packages/webapp/src/routes/__tests__/land/landowner-consent.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/landowner-consent.spec.js
@@ -8,6 +8,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     let postOptions

--- a/packages/webapp/src/routes/__tests__/land/legal-agreement-start-date-spec.js
+++ b/packages/webapp/src/routes/__tests__/land/legal-agreement-start-date-spec.js
@@ -8,8 +8,11 @@ const url = constants.routes.LEGAL_AGREEMENT_START_DATE
 describe(url, () => {
   describe('GET', () => {
     it(`should render the ${url.substring(1)} view`, async () => {
-      const response = await submitGetRequest({ url })
-      expect(response.statusCode).toBe(200)
+      await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
     })
 
     it(`should render the ${url.substring(1)} view date selected`, async () => {

--- a/packages/webapp/src/routes/__tests__/land/legal-agreement-type.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/legal-agreement-type.spec.js
@@ -7,10 +7,12 @@ describe(url, () => {
   const redisMap = new Map()
   describe('GET', () => {
     it(`should render the ${url.substring(1)} view without any selection`, async () => {
-      const response = await submitGetRequest({ url })
-      expect(response.statusCode).toBe(200)
+      await submitGetRequest({ url })
     })
-
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
     it(`should render the ${url.substring(1)} view with conservation selected`, async () => {
       jest.isolateModules(async () => {
         redisMap.set(constants.redisKeys.LEGAL_AGREEMENT_DOCUMENT_TYPE, '759150001')

--- a/packages/webapp/src/routes/__tests__/land/management-monitoring-start-date.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/management-monitoring-start-date.spec.js
@@ -9,6 +9,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     let postOptions

--- a/packages/webapp/src/routes/__tests__/land/register-land-task-list.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/register-land-task-list.spec.js
@@ -12,6 +12,13 @@ describe(url, () => {
         url
       }
     })
+    it(`should render the ${url.substring(1)} view`, async () => {
+      await submitGetRequest({ url })
+    })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
     it('should render view with no completed task', async () => {
       let viewResult, contextResult
       const h = {

--- a/packages/webapp/src/routes/__tests__/land/registered-landowner.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/registered-landowner.spec.js
@@ -8,6 +8,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
   describe('POST', () => {
     let postOptions

--- a/packages/webapp/src/routes/__tests__/land/upload-geospatial.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-geospatial.spec.js
@@ -18,6 +18,10 @@ describe(url, () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/upload-land-boundary.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-land-boundary.spec.js
@@ -16,6 +16,10 @@ describe('Land boundary upload controller tests', () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/upload-legal-agreement.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-legal-agreement.spec.js
@@ -15,6 +15,10 @@ describe('Legal agreement upload controller tests', () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/upload-management-plan.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-management-plan.spec.js
@@ -15,6 +15,10 @@ describe('Management plan upload controller tests', () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/upload-metric.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-metric.spec.js
@@ -16,6 +16,10 @@ describe('Metric file upload controller tests', () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/__tests__/land/upload-ownership-proof.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-ownership-proof.spec.js
@@ -15,6 +15,10 @@ describe('Proof of ownership upload controller tests', () => {
     it(`should render the ${url.substring(1)} view`, async () => {
       await submitGetRequest({ url })
     })
+    it('should redirect to Start page if no data applicant data is available in session', async () => {
+      const response = await submitGetRequest({ url }, 302, {})
+      expect(response.headers.location).toEqual(constants.routes.START)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/land/add-grid-reference.js
+++ b/packages/webapp/src/routes/land/add-grid-reference.js
@@ -1,6 +1,6 @@
 import ngrToBng from '@defra/ngr-to-bng'
 import constants from '../../utils/constants.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 import { postJson } from '../../utils/http.js'
 
 const handlers = {
@@ -64,7 +64,10 @@ const convertGridReferenceToPoint = gridReference => ngrToBng(gridReference)
 export default [{
   method: 'GET',
   path: constants.routes.ADD_GRID_REFERENCE,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.ADD_GRID_REFERENCE,

--- a/packages/webapp/src/routes/land/add-hectares.js
+++ b/packages/webapp/src/routes/land/add-hectares.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -48,7 +48,10 @@ const validateHectares = hectares => {
 export default [{
   method: 'GET',
   path: constants.routes.ADD_HECTARES,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.ADD_HECTARES,

--- a/packages/webapp/src/routes/land/add-landowners.js
+++ b/packages/webapp/src/routes/land/add-landowners.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -50,7 +50,10 @@ const validateLandowners = landowners => {
 export default [{
   method: 'GET',
   path: constants.routes.ADD_LANDOWNERS,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.ADD_LANDOWNERS,

--- a/packages/webapp/src/routes/land/add-legal-agreement-parties.js
+++ b/packages/webapp/src/routes/land/add-legal-agreement-parties.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 function processEmptyPartySelection (partySelectionData, index, combinedError, startId) {
   const errorConstruct = {
@@ -192,7 +192,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.ADD_LEGAL_AGREEMENT_PARTIES,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.ADD_LEGAL_AGREEMENT_PARTIES,

--- a/packages/webapp/src/routes/land/check-and-submit.js
+++ b/packages/webapp/src/routes/land/check-and-submit.js
@@ -2,7 +2,16 @@ import constants from '../../utils/constants.js'
 import application from '../../utils/application.js'
 import applicationValidation from '../../utils/application-validation.js'
 import { postJson } from '../../utils/http.js'
-import { listArray, boolToYesNo, dateToString, hideClass, getAllLandowners, getLegalAgreementDocumentType, getNameAndRoles } from '../../utils/helpers.js'
+import {
+  listArray,
+  boolToYesNo,
+  dateToString,
+  hideClass,
+  getAllLandowners,
+  getLegalAgreementDocumentType,
+  getNameAndRoles,
+  checkApplicantDetails
+} from '../../utils/helpers.js'
 import geospatialOrLandBoundaryContext from './helpers/geospatial-or-land-boundary-context.js'
 
 const handlers = {
@@ -43,7 +52,10 @@ const getContext = request => {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_AND_SUBMIT,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_AND_SUBMIT,

--- a/packages/webapp/src/routes/land/check-geospatial-file.js
+++ b/packages/webapp/src/routes/land/check-geospatial-file.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 import { deleteBlobFromContainers } from '../../utils/azure-storage.js'
 
 const handlers = {
@@ -53,7 +53,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_GEOSPATIAL_FILE,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_GEOSPATIAL_FILE,

--- a/packages/webapp/src/routes/land/check-habitat-baseline.js
+++ b/packages/webapp/src/routes/land/check-habitat-baseline.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask, checked, habitatTypeAndConditionMapper } from '../../utils/helpers.js'
+import { processRegistrationTask, checked, habitatTypeAndConditionMapper, checkApplicantDetails } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -23,7 +23,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_HABITAT_BASELINE,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_HABITAT_BASELINE,

--- a/packages/webapp/src/routes/land/check-habitat-created.js
+++ b/packages/webapp/src/routes/land/check-habitat-created.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask, habitatTypeAndConditionMapper, combineHabitats } from '../../utils/helpers.js'
+import { processRegistrationTask, habitatTypeAndConditionMapper, combineHabitats, checkApplicantDetails } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -23,7 +23,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_HABITAT_CREATED,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_HABITAT_CREATED,

--- a/packages/webapp/src/routes/land/check-land-boundary-details.js
+++ b/packages/webapp/src/routes/land/check-land-boundary-details.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 import geospatialOrLandBoundaryContext from './helpers/geospatial-or-land-boundary-context.js'
 
 const handlers = {
@@ -21,7 +21,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_LAND_BOUNDARY_DETAILS,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_LAND_BOUNDARY_DETAILS,

--- a/packages/webapp/src/routes/land/check-land-boundary-file.js
+++ b/packages/webapp/src/routes/land/check-land-boundary-file.js
@@ -1,6 +1,6 @@
 import constants from '../../utils/constants.js'
 import path from 'path'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 import { deleteBlobFromContainers } from '../../utils/azure-storage.js'
 
 const href = '#check-upload-correct-yes'
@@ -53,7 +53,10 @@ const getContext = request => {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_LAND_BOUNDARY,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_LAND_BOUNDARY,

--- a/packages/webapp/src/routes/land/check-legal-agreement-details.js
+++ b/packages/webapp/src/routes/land/check-legal-agreement-details.js
@@ -1,6 +1,6 @@
 import constants from '../../utils/constants.js'
 import path from 'path'
-import { processRegistrationTask, getNameAndRoles, dateToString, listArray, getLegalAgreementDocumentType } from '../../utils/helpers.js'
+import { processRegistrationTask, getNameAndRoles, dateToString, listArray, getLegalAgreementDocumentType, checkApplicantDetails } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -36,7 +36,10 @@ const getLegalAgreementFileName = fileLocation => fileLocation ? path.parse(file
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_LEGAL_AGREEMENT_DETAILS,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_LEGAL_AGREEMENT_DETAILS,

--- a/packages/webapp/src/routes/land/check-legal-agreement-file.js
+++ b/packages/webapp/src/routes/land/check-legal-agreement-file.js
@@ -1,6 +1,6 @@
 import constants from '../../utils/constants.js'
 import path from 'path'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 import { deleteBlobFromContainers } from '../../utils/azure-storage.js'
 
 const handlers = {
@@ -48,7 +48,10 @@ const getContext = request => {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_LEGAL_AGREEMENT,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_LEGAL_AGREEMENT,

--- a/packages/webapp/src/routes/land/check-management-monitoring-details.js
+++ b/packages/webapp/src/routes/land/check-management-monitoring-details.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask, getFormattedDate } from '../../utils/helpers.js'
+import { processRegistrationTask, getFormattedDate, checkApplicantDetails } from '../../utils/helpers.js'
 import path from 'path'
 
 const handlers = {
@@ -39,7 +39,10 @@ function getManagementFileName (request) {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_MANAGEMENT_MONITORING_DETAILS,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_MANAGEMENT_MONITORING_DETAILS,

--- a/packages/webapp/src/routes/land/check-management-plan-file.js
+++ b/packages/webapp/src/routes/land/check-management-plan-file.js
@@ -1,6 +1,6 @@
 import constants from '../../utils/constants.js'
 import path from 'path'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 import { deleteBlobFromContainers } from '../../utils/azure-storage.js'
 
 const handlers = {
@@ -47,7 +47,10 @@ const getContext = request => {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_MANAGEMENT_PLAN,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_MANAGEMENT_PLAN,

--- a/packages/webapp/src/routes/land/check-metric-details.js
+++ b/packages/webapp/src/routes/land/check-metric-details.js
@@ -1,6 +1,6 @@
 import path from 'path'
 import constants from '../../utils/constants.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -25,7 +25,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_METRIC_DETAILS,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_METRIC_DETAILS,

--- a/packages/webapp/src/routes/land/check-metric-file.js
+++ b/packages/webapp/src/routes/land/check-metric-file.js
@@ -1,6 +1,6 @@
 import constants from '../../utils/constants.js'
 import path from 'path'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 import { deleteBlobFromContainers } from '../../utils/azure-storage.js'
 
 const href = '#check-upload-correct-yes'
@@ -53,7 +53,10 @@ const getContext = request => {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_UPLOAD_METRIC,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_UPLOAD_METRIC,

--- a/packages/webapp/src/routes/land/check-ownership-details.js
+++ b/packages/webapp/src/routes/land/check-ownership-details.js
@@ -1,7 +1,7 @@
 // THIS is just a placeholder route the ticket hasn't come in to sprint yet so is subject to change.
 import constants from '../../utils/constants.js'
 import path from 'path'
-import { boolToYesNo, listArray, processRegistrationTask, getAllLandowners } from '../../utils/helpers.js'
+import { boolToYesNo, listArray, processRegistrationTask, getAllLandowners, checkApplicantDetails } from '../../utils/helpers.js'
 const handlers = {
   get: async (request, h) => {
     processRegistrationTask(request, {
@@ -29,7 +29,10 @@ function getOwnershipFileName (fileLocation) {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_OWNERSHIP_DETAILS,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_OWNERSHIP_DETAILS,

--- a/packages/webapp/src/routes/land/check-ownership-proof-file.js
+++ b/packages/webapp/src/routes/land/check-ownership-proof-file.js
@@ -1,6 +1,6 @@
 import constants from '../../utils/constants.js'
 import path from 'path'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 import { deleteBlobFromContainers } from '../../utils/azure-storage.js'
 
 const handlers = {
@@ -47,7 +47,10 @@ const getContext = request => {
 export default [{
   method: 'GET',
   path: constants.routes.CHECK_PROOF_OF_OWNERSHIP,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHECK_PROOF_OF_OWNERSHIP,

--- a/packages/webapp/src/routes/land/choose-land-boundary-upload.js
+++ b/packages/webapp/src/routes/land/choose-land-boundary-upload.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { checked, processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, checked, processRegistrationTask } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -53,7 +53,10 @@ const getContext = request => {
 export default [{
   method: 'GET',
   path: constants.routes.CHOOSE_LAND_BOUNDARY_UPLOAD,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.CHOOSE_LAND_BOUNDARY_UPLOAD,

--- a/packages/webapp/src/routes/land/download-geospatial-land-boundary-file.js
+++ b/packages/webapp/src/routes/land/download-geospatial-land-boundary-file.js
@@ -2,8 +2,9 @@ import path from 'path'
 import { blobStorageConnector } from '@defra/bng-connectors-lib'
 import constants from '../../utils/constants.js'
 import { logger } from 'defra-logging-facade'
+import { checkApplicantDetails } from '../../utils/helpers.js'
 
-const downloadLegalAgreementFile = async (request, h) => {
+const downloadGeospatialLandBoundaryFile = async (request, h) => {
   const blobName = request.yar.get(constants.redisKeys.GEOSPATIAL_UPLOAD_LOCATION)
   const config = {
     blobName,
@@ -17,5 +18,8 @@ const downloadLegalAgreementFile = async (request, h) => {
 export default {
   method: 'GET',
   path: constants.routes.DOWNLOAD_GEOSPATIAL_LAND_BOUNDARY,
-  handler: downloadLegalAgreementFile
+  handler: downloadGeospatialLandBoundaryFile,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }

--- a/packages/webapp/src/routes/land/download-land-boundary-file.js
+++ b/packages/webapp/src/routes/land/download-land-boundary-file.js
@@ -4,7 +4,7 @@ import constants from '../../utils/constants.js'
 import { logger } from 'defra-logging-facade'
 import { checkApplicantDetails } from '../../utils/helpers.js'
 
-const downloadLegalAgreementFile = async (request, h) => {
+const downloadLandBoundaryFile = async (request, h) => {
   const blobName = request.yar.get(constants.redisKeys.LAND_BOUNDARY_LOCATION)
   const config = {
     blobName,
@@ -18,7 +18,7 @@ const downloadLegalAgreementFile = async (request, h) => {
 export default {
   method: 'GET',
   path: constants.routes.DOWNLOAD_LAND_BOUNDARY,
-  handler: downloadLegalAgreementFile,
+  handler: downloadLandBoundaryFile,
   config: {
     pre: [checkApplicantDetails]
   }

--- a/packages/webapp/src/routes/land/download-land-boundary-file.js
+++ b/packages/webapp/src/routes/land/download-land-boundary-file.js
@@ -2,6 +2,7 @@ import path from 'path'
 import { blobStorageConnector } from '@defra/bng-connectors-lib'
 import constants from '../../utils/constants.js'
 import { logger } from 'defra-logging-facade'
+import { checkApplicantDetails } from '../../utils/helpers.js'
 
 const downloadLegalAgreementFile = async (request, h) => {
   const blobName = request.yar.get(constants.redisKeys.LAND_BOUNDARY_LOCATION)
@@ -17,5 +18,8 @@ const downloadLegalAgreementFile = async (request, h) => {
 export default {
   method: 'GET',
   path: constants.routes.DOWNLOAD_LAND_BOUNDARY,
-  handler: downloadLegalAgreementFile
+  handler: downloadLegalAgreementFile,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }

--- a/packages/webapp/src/routes/land/download-land-ownership-file.js
+++ b/packages/webapp/src/routes/land/download-land-ownership-file.js
@@ -2,6 +2,7 @@ import path from 'path'
 import { blobStorageConnector } from '@defra/bng-connectors-lib'
 import constants from '../../utils/constants.js'
 import { logger } from 'defra-logging-facade'
+import { checkApplicantDetails } from '../../utils/helpers.js'
 
 const downloadLegalAgreementFile = async (request, h) => {
   const blobName = request.yar.get(constants.redisKeys.LAND_OWNERSHIP_LOCATION)
@@ -17,5 +18,8 @@ const downloadLegalAgreementFile = async (request, h) => {
 export default {
   method: 'GET',
   path: constants.routes.DOWNLOAD_LAND_OWNERSHIP,
-  handler: downloadLegalAgreementFile
+  handler: downloadLegalAgreementFile,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }

--- a/packages/webapp/src/routes/land/download-land-ownership-file.js
+++ b/packages/webapp/src/routes/land/download-land-ownership-file.js
@@ -4,7 +4,7 @@ import constants from '../../utils/constants.js'
 import { logger } from 'defra-logging-facade'
 import { checkApplicantDetails } from '../../utils/helpers.js'
 
-const downloadLegalAgreementFile = async (request, h) => {
+const downloadLandOwnershipFile = async (request, h) => {
   const blobName = request.yar.get(constants.redisKeys.LAND_OWNERSHIP_LOCATION)
   const config = {
     blobName,
@@ -18,7 +18,7 @@ const downloadLegalAgreementFile = async (request, h) => {
 export default {
   method: 'GET',
   path: constants.routes.DOWNLOAD_LAND_OWNERSHIP,
-  handler: downloadLegalAgreementFile,
+  handler: downloadLandOwnershipFile,
   config: {
     pre: [checkApplicantDetails]
   }

--- a/packages/webapp/src/routes/land/download-legal-agreement-file.js
+++ b/packages/webapp/src/routes/land/download-legal-agreement-file.js
@@ -2,6 +2,7 @@ import path from 'path'
 import { blobStorageConnector } from '@defra/bng-connectors-lib'
 import constants from '../../utils/constants.js'
 import { logger } from 'defra-logging-facade'
+import { checkApplicantDetails } from '../../utils/helpers.js'
 
 const downloadLegalAgreementFile = async (request, h) => {
   const blobName = request.yar.get(constants.redisKeys.LEGAL_AGREEMENT_LOCATION)
@@ -17,5 +18,8 @@ const downloadLegalAgreementFile = async (request, h) => {
 export default {
   method: 'GET',
   path: constants.routes.DOWNLOAD_LEGAL_AGREEMENT,
-  handler: downloadLegalAgreementFile
+  handler: downloadLegalAgreementFile,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }

--- a/packages/webapp/src/routes/land/download-management-plan-file.js
+++ b/packages/webapp/src/routes/land/download-management-plan-file.js
@@ -2,6 +2,7 @@ import path from 'path'
 import { blobStorageConnector } from '@defra/bng-connectors-lib'
 import constants from '../../utils/constants.js'
 import { logger } from 'defra-logging-facade'
+import { checkApplicantDetails } from '../../utils/helpers.js'
 
 const downloadManagementPlanFile = async (request, h) => {
   const blobName = request.yar.get(constants.redisKeys.MANAGEMENT_PLAN_LOCATION)
@@ -17,5 +18,8 @@ const downloadManagementPlanFile = async (request, h) => {
 export default {
   method: 'GET',
   path: constants.routes.DOWNLOAD_MANAGEMENT_PLAN,
-  handler: downloadManagementPlanFile
+  handler: downloadManagementPlanFile,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }

--- a/packages/webapp/src/routes/land/download-metric-file.js
+++ b/packages/webapp/src/routes/land/download-metric-file.js
@@ -4,7 +4,7 @@ import constants from '../../utils/constants.js'
 import { logger } from 'defra-logging-facade'
 import { checkApplicantDetails } from '../../utils/helpers.js'
 
-const downloadManagementPlanFile = async (request, h) => {
+const downloadMetricFile = async (request, h) => {
   const blobName = request.yar.get(constants.redisKeys.METRIC_LOCATION)
   const config = {
     blobName,
@@ -18,7 +18,7 @@ const downloadManagementPlanFile = async (request, h) => {
 export default {
   method: 'GET',
   path: constants.routes.DOWNLOAD_METRIC_FILE,
-  handler: downloadManagementPlanFile,
+  handler: downloadMetricFile,
   config: {
     pre: [checkApplicantDetails]
   }

--- a/packages/webapp/src/routes/land/download-metric-file.js
+++ b/packages/webapp/src/routes/land/download-metric-file.js
@@ -2,6 +2,7 @@ import path from 'path'
 import { blobStorageConnector } from '@defra/bng-connectors-lib'
 import constants from '../../utils/constants.js'
 import { logger } from 'defra-logging-facade'
+import { checkApplicantDetails } from '../../utils/helpers.js'
 
 const downloadManagementPlanFile = async (request, h) => {
   const blobName = request.yar.get(constants.redisKeys.METRIC_LOCATION)
@@ -17,5 +18,8 @@ const downloadManagementPlanFile = async (request, h) => {
 export default {
   method: 'GET',
   path: constants.routes.DOWNLOAD_METRIC_FILE,
-  handler: downloadManagementPlanFile
+  handler: downloadManagementPlanFile,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }

--- a/packages/webapp/src/routes/land/habitat-works-start-date.js
+++ b/packages/webapp/src/routes/land/habitat-works-start-date.js
@@ -1,5 +1,6 @@
 import constants from '../../utils/constants.js'
 import {
+  checkApplicantDetails,
   dateClasses,
   getMinDateCheckError,
   processRegistrationTask,
@@ -48,7 +49,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.HABITAT_WORKS_START_DATE,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.HABITAT_WORKS_START_DATE,

--- a/packages/webapp/src/routes/land/landowner-consent.js
+++ b/packages/webapp/src/routes/land/landowner-consent.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -33,7 +33,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.LANDOWNER_CONSENT,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.LANDOWNER_CONSENT,

--- a/packages/webapp/src/routes/land/legal-agreement-start-date.js
+++ b/packages/webapp/src/routes/land/legal-agreement-start-date.js
@@ -1,5 +1,6 @@
 import constants from '../../utils/constants.js'
 import {
+  checkApplicantDetails,
   dateClasses,
   getMinDateCheckError,
   processRegistrationTask,
@@ -47,7 +48,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.LEGAL_AGREEMENT_START_DATE,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.LEGAL_AGREEMENT_START_DATE,

--- a/packages/webapp/src/routes/land/legal-agreement-type.js
+++ b/packages/webapp/src/routes/land/legal-agreement-type.js
@@ -1,5 +1,5 @@
 import constants from '../../utils/constants.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -43,7 +43,10 @@ const getContext = request => {
 export default [{
   method: 'GET',
   path: constants.routes.LEGAL_AGREEMENT_TYPE,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.LEGAL_AGREEMENT_TYPE,

--- a/packages/webapp/src/routes/land/management-monitoring-start-date.js
+++ b/packages/webapp/src/routes/land/management-monitoring-start-date.js
@@ -1,5 +1,6 @@
 import constants from '../../utils/constants.js'
 import {
+  checkApplicantDetails,
   dateClasses,
   getMinDateCheckError,
   isDate1LessThanDate2,
@@ -57,7 +58,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.MANAGEMENT_MONITORING_START_DATE,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.MANAGEMENT_MONITORING_START_DATE,

--- a/packages/webapp/src/routes/land/register-land-task-list.js
+++ b/packages/webapp/src/routes/land/register-land-task-list.js
@@ -1,5 +1,6 @@
 import constants from '../../utils/constants.js'
 import registerTaskList from '../../utils/register-task-list.js'
+import { checkApplicantDetails } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (request, h) => {
@@ -31,5 +32,8 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.REGISTER_LAND_TASK_LIST,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }]

--- a/packages/webapp/src/routes/land/registered-landowner.js
+++ b/packages/webapp/src/routes/land/registered-landowner.js
@@ -1,4 +1,5 @@
 import constants from '../../utils/constants.js'
+import { checkApplicantDetails } from '../../utils/helpers.js'
 
 const handlers = {
   get: async (_request, h) => h.view(constants.views.REGISTERED_LANDOWNER),
@@ -25,7 +26,10 @@ const handlers = {
 export default [{
   method: 'GET',
   path: constants.routes.REGISTERED_LANDOWNER,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.REGISTERED_LANDOWNER,

--- a/packages/webapp/src/routes/land/upload-geospatial-file.js
+++ b/packages/webapp/src/routes/land/upload-geospatial-file.js
@@ -5,7 +5,7 @@ import { handleEvents } from '../../utils/azure-signalr.js'
 import { uploadStreamAndQueueMessage, deleteBlobFromContainers } from '../../utils/azure-storage.js'
 import constants from '../../utils/constants.js'
 import { uploadFiles } from '../../utils/upload.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const invalidUploadErrorText = 'The selected file must be a GeoJSON, Geopackage or Shape file'
 const uploadGeospatialFileId = '#geospatialLandBoundary'
@@ -216,7 +216,10 @@ const getErrorContext = err => {
 export default [{
   method: 'GET',
   path: constants.routes.UPLOAD_GEOSPATIAL_LAND_BOUNDARY,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 }, {
   method: 'POST',
   path: constants.routes.UPLOAD_GEOSPATIAL_LAND_BOUNDARY,

--- a/packages/webapp/src/routes/land/upload-land-boundary.js
+++ b/packages/webapp/src/routes/land/upload-land-boundary.js
@@ -3,7 +3,7 @@ import { handleEvents } from '../../utils/azure-signalr.js'
 import { uploadStreamAndQueueMessage, deleteBlobFromContainers } from '../../utils/azure-storage.js'
 import constants from '../../utils/constants.js'
 import { uploadFiles } from '../../utils/upload.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const LAND_BOUNDARY_ID = '#landBoundary'
 
@@ -148,7 +148,10 @@ const buildFileValidationConfig = config => {
 export default [{
   method: 'GET',
   path: constants.routes.UPLOAD_LAND_BOUNDARY,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 },
 {
   method: 'POST',

--- a/packages/webapp/src/routes/land/upload-legal-agreement.js
+++ b/packages/webapp/src/routes/land/upload-legal-agreement.js
@@ -3,7 +3,7 @@ import { handleEvents } from '../../utils/azure-signalr.js'
 import { uploadStreamAndQueueMessage } from '../../utils/azure-storage.js'
 import constants from '../../utils/constants.js'
 import { uploadFiles } from '../../utils/upload.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 function processSuccessfulUpload (result, request, h) {
   let resultView = constants.views.INTERNAL_SERVER_ERROR
@@ -134,7 +134,10 @@ const buildFileValidationConfig = config => {
 export default [{
   method: 'GET',
   path: constants.routes.UPLOAD_LEGAL_AGREEMENT,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 },
 {
   method: 'POST',

--- a/packages/webapp/src/routes/land/upload-management-plan.js
+++ b/packages/webapp/src/routes/land/upload-management-plan.js
@@ -3,7 +3,7 @@ import { handleEvents } from '../../utils/azure-signalr.js'
 import { uploadStreamAndQueueMessage } from '../../utils/azure-storage.js'
 import constants from '../../utils/constants.js'
 import { uploadFiles } from '../../utils/upload.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const MANAGEMENT_PLAN_ID = '#managementPlan'
 
@@ -135,7 +135,10 @@ function processErrorUpload (err, h) {
 export default [{
   method: 'GET',
   path: constants.routes.UPLOAD_MANAGEMENT_PLAN,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 },
 {
   method: 'POST',

--- a/packages/webapp/src/routes/land/upload-metric.js
+++ b/packages/webapp/src/routes/land/upload-metric.js
@@ -3,7 +3,7 @@ import { handleEvents } from '../../utils/azure-signalr.js'
 import { uploadStreamAndQueueMessage, deleteBlobFromContainers } from '../../utils/azure-storage.js'
 import constants from '../../utils/constants.js'
 import { uploadFiles } from '../../utils/upload.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const UPLOAD_METRIC_ID = '#uploadMetric'
 
@@ -160,7 +160,10 @@ const getValidation = metricValidation => {
 export default [{
   method: 'GET',
   path: constants.routes.UPLOAD_METRIC,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 },
 {
   method: 'POST',

--- a/packages/webapp/src/routes/land/upload-ownership-proof.js
+++ b/packages/webapp/src/routes/land/upload-ownership-proof.js
@@ -3,7 +3,7 @@ import { handleEvents } from '../../utils/azure-signalr.js'
 import { uploadStreamAndQueueMessage } from '../../utils/azure-storage.js'
 import constants from '../../utils/constants.js'
 import { uploadFiles } from '../../utils/upload.js'
-import { processRegistrationTask } from '../../utils/helpers.js'
+import { checkApplicantDetails, processRegistrationTask } from '../../utils/helpers.js'
 
 const LAND_OWNERSHIP_ID = '#landOwnership'
 
@@ -135,7 +135,10 @@ const buildFileValidationConfig = config => {
 export default [{
   method: 'GET',
   path: constants.routes.UPLOAD_LAND_OWNERSHIP,
-  handler: handlers.get
+  handler: handlers.get,
+  config: {
+    pre: [checkApplicantDetails]
+  }
 },
 {
   method: 'POST',

--- a/packages/webapp/src/utils/helpers.js
+++ b/packages/webapp/src/utils/helpers.js
@@ -384,6 +384,20 @@ const emailValidator = (email, id) => {
 // Nunjucks template function
 const getErrById = (err, fieldId) => (err || []).find(e => e.href === `#${fieldId}`)
 
+const areApplicantDetailsPresent = session => (
+  session.get(constants.redisKeys.FULL_NAME) &&
+  session.get(constants.redisKeys.ROLE_KEY) &&
+  session.get(constants.redisKeys.EMAIL_VALUE)
+)
+
+// Route pre lifecycle method, redirects to Start if applicant details are not present
+const checkApplicantDetails = (request, h) => {
+  if (!areApplicantDetailsPresent(request.yar)) {
+    return h.redirect(constants.routes.START).takeover()
+  }
+  return h.continue
+}
+
 export {
   validateDate,
   dateClasses,
@@ -412,5 +426,6 @@ export {
   emailValidator,
   getDeveloperEligibilityResults,
   validateBNGNumber,
-  getErrById
+  getErrById,
+  checkApplicantDetails
 }


### PR DESCRIPTION
- Added in pre option function for routes that need to check for applicant details in session
- Added method to inject session data prior to using server.inject, so that we can manipulate the session within the unit test
- Updated a load of route tests to use the standard server.inject as they are now able to complete correctly due to the presence of the session data