### PR TITLE
BNGP-3020 fixing flaky queue connector unit test

### DIFF
--- a/packages/connectors-lib/src/__tests__/azure-storage-queue-connector.spec.js
+++ b/packages/connectors-lib/src/__tests__/azure-storage-queue-connector.spec.js
@@ -14,7 +14,7 @@ describe('The Azure blob storage connector', () => {
     }
 
     const config = {
-      queueName: 'signalr-test-queue',
+      queueName: 'trusted-file-queue',
       message: Buffer.from(JSON.stringify(jsonMessage)).toString(base64)
     }
 


### PR DESCRIPTION
switching queue connector test to use trusted-file-queue as signalr-test-queue has flakey issues due to mocked 2 second delay, potentially