### PR TITLE
Feature/BNGP-4607: Fix typo headgerow on credits estimation page

### DIFF
--- a/packages/webapp/src/views/credits-estimation/credits-tier.html
+++ b/packages/webapp/src/views/credits-estimation/credits-tier.html
@@ -101,7 +101,7 @@
             }) }}
           </div>
           <div class="govuk-grid-column-one-third">
-            <span class="govuk-caption-m">Headgerow</span>
+            <span class="govuk-caption-m">Hedgerow</span>
             <h2 class="govuk-heading-l">Tier H</h2>
             {{ govukInput({
               id: "h-units",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-4607

This change fixes the typo headgerow for hedgerow