### PR TITLE
fix/BNGP-4963: Include details needed for token refresh in cookie

### DIFF
--- a/packages/webapp/package-lock.json
+++ b/packages/webapp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webapp",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webapp",
-      "version": "1.56.0",
+      "version": "1.56.1",
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
@@ -480,39 +480,39 @@
       }
     },
     "node_modules/@defra/bng-azure-storage-test-utils": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@defra/bng-azure-storage-test-utils/-/bng-azure-storage-test-utils-1.54.0.tgz",
-      "integrity": "sha512-a1CArdL3TXIvLG4hS6f8Qice12s0y4BU4GSuBejixRAcn2giRSvsc9ZPZOj0zlKD29pk1KgnjPZ1C3bZEt2w+Q==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@defra/bng-azure-storage-test-utils/-/bng-azure-storage-test-utils-1.56.0.tgz",
+      "integrity": "sha512-+7eqMBdVKIiRvKwd7gDzPTaE53UbGUtnoWmfqTHcNRhNoSIkS1JLqnvv+gbLMoyUz59gUZ4Wah2S3JqrNjzwgQ==",
       "dev": true,
       "dependencies": {
-        "@defra/bng-connectors-lib": "1.54.0",
-        "@defra/bng-utils-lib": "1.54.0"
+        "@defra/bng-connectors-lib": "1.56.0",
+        "@defra/bng-utils-lib": "1.56.0"
       }
     },
     "node_modules/@defra/bng-connectors-lib": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@defra/bng-connectors-lib/-/bng-connectors-lib-1.54.0.tgz",
-      "integrity": "sha512-ZtYJdzCS1gBbxW91SqV6xDZ17kUsZduQXc9M2VFbFp8Dj3PltcpV8mRDXkScZtAC85i4w9xIGY1UNhv3dGv7XA==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@defra/bng-connectors-lib/-/bng-connectors-lib-1.56.0.tgz",
+      "integrity": "sha512-pDY/LG7a3wsX65X5r1ZcoTwlXrbk/Ib9BjT9uf0t05GYc6kjCXDTIKyeDr4vGbEMVHEHVHaWWOxzZVIArb1jww==",
       "dependencies": {
         "@azure/service-bus": "^7.9.2",
         "@azure/storage-blob": "^12.16.0",
         "@azure/storage-queue": "^12.15.0",
-        "@defra/bng-utils-lib": "1.54.0",
+        "@defra/bng-utils-lib": "1.56.0",
         "pg": "^8.11.3"
       }
     },
     "node_modules/@defra/bng-errors-lib": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@defra/bng-errors-lib/-/bng-errors-lib-1.54.0.tgz",
-      "integrity": "sha512-aYJmhSc8XJ0k5tnz9btQFTDzx7j3qzTLBANAUcpUqLn4R5kOjNLtBsMZQ+qba8wDDYZZ11Njrg47y1UCeO23nQ=="
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@defra/bng-errors-lib/-/bng-errors-lib-1.56.0.tgz",
+      "integrity": "sha512-RwelIAkYGI5PNjjglLfcjyyLcPMBgpefpkhsTJkqdgpcqxHjKdbcRJJ8cDX4czpjEIsJHy5eRc/boUML0Fcoew=="
     },
     "node_modules/@defra/bng-utils-lib": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/@defra/bng-utils-lib/-/bng-utils-lib-1.54.0.tgz",
-      "integrity": "sha512-VegrRby3VdJgtnWjfOXOLsDCZMJIYk3YNeEyZmX4OTn0n71uk6D+sGAGBxhgKwOl61lAuPpIKZ1m+pQsyB5p7g==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@defra/bng-utils-lib/-/bng-utils-lib-1.56.0.tgz",
+      "integrity": "sha512-o4bpQbuppwfjcqhaKwKar2WQMwbOHPEBhNAdRRWn4LWhELkO8xE8okx8pOa6EoK5RfRB1LekL1vE4rb+vfTJcA==",
       "dependencies": {
         "@azure/identity": "^4.0.0",
-        "@defra/bng-connectors-lib": "1.54.0",
+        "@defra/bng-connectors-lib": "1.56.0",
         "axios": "^1.6.2",
         "pino": "^8.17.2",
         "pino-pretty": "10.3.1"

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp",
-  "version": "1.56.0",
+  "version": "1.56.1",
   "private": true,
   "type": "module",
   "description": "",

--- a/packages/webapp/src/utils/auth.js
+++ b/packages/webapp/src/utils/auth.js
@@ -37,9 +37,12 @@ const getAuthenticationUrl = () => {
   return msalClientApplication.getAuthCodeUrl(authCodeUrlParameters)
 }
 
-const setCookie = (cookieAuth, token) => cookieAuth.set({
-  account: { idTokenClaims: token?.account?.idTokenClaims }
-})
+const setCookie = (cookieAuth, token) => {
+  delete token?.account?.idToken
+  cookieAuth.set({
+    account: token?.account
+  })
+}
 
 const authenticate = async (code, cookieAuth) => {
   const { redirectUri } = authConfig


### PR DESCRIPTION
This PR/branch SHOULD NOT BE MERGED INTO MASTER.

It has been branched off the commit to create 1.56.0 which is the release candidate for credits purchase. Just this fix has been applied so it can proceed to release. Fix will be applied separately to master branch which is now ahead of 1.56.0

https://eaflood.atlassian.net/browse/BNGP-4963