### PR TITLE
BNGP-5210: fix referer logic for changing metric upload

### DIFF
--- a/packages/webapp/src/utils/developer-constants.js
+++ b/packages/webapp/src/utils/developer-constants.js
@@ -89,7 +89,6 @@ const DEVELOPER_PROOF_OF_PERMISSION_SEEN = 'developer-proof-of-permission-seen'
 const DEVELOPER_APPLICATION_SUBMITTED = 'developer-application-submitted'
 
 const setDeveloperReferer = [
-  DEVELOPER_CONFIRM_OFF_SITE_GAIN,
   DEVELOPER_AGREEMENT_CHECK,
   DEVELOPER_CHECK_AND_SUBMIT
 ]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5210

Fixes https://eaflood.atlassian.net/browse/BNGP-5201

The current referer logic means the upload metric file pages are skipped when going back to change the metric file from the check metric details page in the developer journey. We fix this by updating the logic to no longer skip the pages if coming from the `developer/confirm-off-site-gain` route.