### PR TITLE
BNGP-5184: Remove query code from allocation API call

### DIFF
--- a/packages/webapp/src/routes/__tests__/developer/biodiversity-gain-site-number.spec.js
+++ b/packages/webapp/src/routes/__tests__/developer/biodiversity-gain-site-number.spec.js
@@ -1,5 +1,6 @@
 import { submitGetRequest, submitPostRequest } from '../helpers/server.js'
 import constants from '../../../utils/constants.js'
+import wreck from '@hapi/wreck'
 const url = constants.routes.DEVELOPER_BNG_NUMBER
 
 describe(url, () => {
@@ -166,6 +167,43 @@ describe(url, () => {
       const developerBgsNumber = require('../../developer/biodiversity-gain-site-number')
       await developerBgsNumber.default[1].handler(request, h)
       expect(viewResult).toBe(constants.routes.DEVELOPER_UPLOAD_METRIC)
+    })
+
+    // TODO: Either configure BACKEND_API_CODE_QUERY_PARAMETER env var with a test value, or mock
+    // `BACKEND_API.CODE_QUERY_PARAMETER` in config.js
+    it('Should call the API with a `code` query param if one is configured', done => {
+      jest.isolateModules(async () => {
+        try {
+          jest.resetAllMocks()
+          jest.mock('@hapi/wreck')
+          const spy = jest.spyOn(wreck, 'get')
+
+          postOptions.payload.bgsNumber = 'BGS-010124001'
+          await submitPostRequest(postOptions)
+          expect(spy.mock.calls[0][0]).toContain('code=')
+          done()
+        } catch (err) {
+          done(err)
+        }
+      })
+    })
+
+    // TODO: Figure out why src/routes/__tests__/helpers/server.js:167:31 fails when this second test is present
+    it('Should not call the API with a `code` query param if not configured', done => {
+      jest.isolateModules(async () => {
+        try {
+          jest.resetAllMocks()
+          jest.mock('@hapi/wreck')
+          const spy = jest.spyOn(wreck, 'get')
+
+          postOptions.payload.bgsNumber = 'BGS-010124001'
+          await submitPostRequest(postOptions)
+          expect(spy.mock.calls[0][0]).not.toContain('code=')
+          done()
+        } catch (err) {
+          done(err)
+        }
+      })
     })
   })
 })

--- a/packages/webapp/src/routes/__tests__/developer/biodiversity-gain-site-number.spec.js
+++ b/packages/webapp/src/routes/__tests__/developer/biodiversity-gain-site-number.spec.js
@@ -26,6 +26,10 @@ describe(url, () => {
       }
     })
 
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
     it('Should continue journey if valid BGS number provided', async () => {
       postOptions.payload.bgsNumber = 'BGS-010124001'
       const res = await submitPostRequest(postOptions)
@@ -173,7 +177,6 @@ describe(url, () => {
     it('Should call the API with a `code` query param if one is configured', done => {
       jest.isolateModules(async () => {
         try {
-          jest.resetAllMocks()
           jest.mock('@hapi/wreck')
           const spy = jest.spyOn(wreck, 'get')
           jest.replaceProperty(BACKEND_API, 'CODE_QUERY_PARAMETER', 'test123')
@@ -188,13 +191,12 @@ describe(url, () => {
       })
     })
 
-    // TODO: Figure out why src/routes/__tests__/helpers/server.js:167:31 fails when this second test is present
     it('Should not call the API with a `code` query param if not configured', done => {
       jest.isolateModules(async () => {
         try {
-          jest.resetAllMocks()
           jest.mock('@hapi/wreck')
           const spy = jest.spyOn(wreck, 'get')
+          jest.replaceProperty(BACKEND_API, 'CODE_QUERY_PARAMETER', undefined)
 
           postOptions.payload.bgsNumber = 'BGS-010124001'
           await submitPostRequest(postOptions)

--- a/packages/webapp/src/routes/__tests__/developer/biodiversity-gain-site-number.spec.js
+++ b/packages/webapp/src/routes/__tests__/developer/biodiversity-gain-site-number.spec.js
@@ -1,6 +1,7 @@
 import { submitGetRequest, submitPostRequest } from '../helpers/server.js'
 import constants from '../../../utils/constants.js'
 import wreck from '@hapi/wreck'
+import { BACKEND_API } from '../../../utils/config.js'
 const url = constants.routes.DEVELOPER_BNG_NUMBER
 
 describe(url, () => {
@@ -169,18 +170,17 @@ describe(url, () => {
       expect(viewResult).toBe(constants.routes.DEVELOPER_UPLOAD_METRIC)
     })
 
-    // TODO: Either configure BACKEND_API_CODE_QUERY_PARAMETER env var with a test value, or mock
-    // `BACKEND_API.CODE_QUERY_PARAMETER` in config.js
     it('Should call the API with a `code` query param if one is configured', done => {
       jest.isolateModules(async () => {
         try {
           jest.resetAllMocks()
           jest.mock('@hapi/wreck')
           const spy = jest.spyOn(wreck, 'get')
+          jest.replaceProperty(BACKEND_API, 'CODE_QUERY_PARAMETER', 'test123')
 
           postOptions.payload.bgsNumber = 'BGS-010124001'
           await submitPostRequest(postOptions)
-          expect(spy.mock.calls[0][0]).toContain('code=')
+          expect(spy.mock.calls[0][0]).toContain('code=test123')
           done()
         } catch (err) {
           done(err)

--- a/packages/webapp/src/routes/__tests__/developer/biodiversity-gain-site-number.spec.js
+++ b/packages/webapp/src/routes/__tests__/developer/biodiversity-gain-site-number.spec.js
@@ -175,38 +175,24 @@ describe(url, () => {
       expect(viewResult).toBe(constants.routes.DEVELOPER_UPLOAD_METRIC)
     })
 
-    it('Should call the API with a `code` query param if one is configured', done => {
-      jest.isolateModules(async () => {
-        try {
-          jest.mock('@hapi/wreck')
-          const spy = jest.spyOn(wreck, 'get')
-          jest.replaceProperty(BACKEND_API, 'CODE_QUERY_PARAMETER', 'test123')
+    it('Should call the API with a `code` query param if one is configured', async () => {
+      jest.mock('@hapi/wreck')
+      const spy = jest.spyOn(wreck, 'get')
+      jest.replaceProperty(BACKEND_API, 'CODE_QUERY_PARAMETER', 'test123')
 
-          postOptions.payload.bgsNumber = 'BGS-010124001'
-          await submitPostRequest(postOptions)
-          expect(spy.mock.calls[0][0]).toContain('code=test123')
-          done()
-        } catch (err) {
-          done(err)
-        }
-      })
+      postOptions.payload.bgsNumber = 'BGS-010124001'
+      await submitPostRequest(postOptions)
+      expect(spy.mock.calls[0][0]).toContain('code=test123')
     })
 
-    it('Should not call the API with a `code` query param if not configured', done => {
-      jest.isolateModules(async () => {
-        try {
-          jest.mock('@hapi/wreck')
-          const spy = jest.spyOn(wreck, 'get')
-          jest.replaceProperty(BACKEND_API, 'CODE_QUERY_PARAMETER', undefined)
+    it('Should not call the API with a `code` query param if one is not configured', async () => {
+      jest.mock('@hapi/wreck')
+      const spy = jest.spyOn(wreck, 'get')
+      jest.replaceProperty(BACKEND_API, 'CODE_QUERY_PARAMETER', undefined)
 
-          postOptions.payload.bgsNumber = 'BGS-010124001'
-          await submitPostRequest(postOptions)
-          expect(spy.mock.calls[0][0]).not.toContain('code=')
-          done()
-        } catch (err) {
-          done(err)
-        }
-      })
+      postOptions.payload.bgsNumber = 'BGS-010124001'
+      await submitPostRequest(postOptions)
+      expect(spy.mock.calls[0][0]).not.toContain('code=')
     })
   })
 })

--- a/packages/webapp/src/routes/developer/biodiversity-gain-site-number.js
+++ b/packages/webapp/src/routes/developer/biodiversity-gain-site-number.js
@@ -4,7 +4,9 @@ import wreck from '@hapi/wreck'
 
 const getGainSiteApiUrl = bgsNumber => {
   const url = new URL(`${BACKEND_API.BASE_URL}gainsite/${bgsNumber}`)
-  url.searchParams.set('code', BACKEND_API.CODE_QUERY_PARAMETER)
+  if (BACKEND_API.CODE_QUERY_PARAMETER) {
+    url.searchParams.set('code', BACKEND_API.CODE_QUERY_PARAMETER)
+  }
   return url
 }
 

--- a/packages/webapp/src/routes/developer/biodiversity-gain-site-number.js
+++ b/packages/webapp/src/routes/developer/biodiversity-gain-site-number.js
@@ -2,7 +2,11 @@ import constants from '../../utils/constants.js'
 import { BACKEND_API } from '../../utils/config.js'
 import wreck from '@hapi/wreck'
 
-const getGainSiteApiUrl = bgsNumber => new URL(`${BACKEND_API.BASE_URL}gainsite/${bgsNumber}?code=${BACKEND_API.CODE_QUERY_PARAMETER}`)
+const getGainSiteApiUrl = bgsNumber => {
+  const url = new URL(`${BACKEND_API.BASE_URL}gainsite/${bgsNumber}`)
+  url.searchParams.set('code', BACKEND_API.CODE_QUERY_PARAMETER)
+  return url
+}
 
 const getStatusErrorMessage = status => {
   switch (status.toLowerCase()) {

--- a/packages/webapp/src/utils/config.js
+++ b/packages/webapp/src/utils/config.js
@@ -31,5 +31,5 @@ export const BACS_SWIFT_CODE = process.env.BACS_SWIFT_CODE || 'ABCDEF2G'
 export const BACKEND_API = {
   BASE_URL: process.env.BACKEND_API_BASE_URL ?? 'http://localhost:3000/test/api/',
   SUBSCRIPTION_KEY: process.env.BACKEND_API_SUBSCRIPTION_KEY ?? 'test123',
-  CODE_QUERY_PARAMETER: process.env.BACKEND_API_CODE_QUERY_PARAMETER ?? 'test123'
+  CODE_QUERY_PARAMETER: process.env.BACKEND_API_CODE_QUERY_PARAMETER
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5184

APIM will inject query code used in API call if it isn’t present, so we only want to inject it ourselves based on the value in an environment variable. This PR does this by removing the default value for the `BACKEND_API.CODE_QUERY_PARAMETER` config item, and makes setting the query param conditional based on whether the config item has a value.