### PR TITLE
BNGP-5077: Remove 'optional' property from payloads

### DIFF
--- a/packages/webapp/src/utils/application-validation.js
+++ b/packages/webapp/src/utils/application-validation.js
@@ -138,7 +138,7 @@ const applicationValidation = Joi.object({
           then: Joi.string().allow(null),
           otherwise: Joi.string().required()
         }),
-        optional: Joi.boolean().required()
+        optional: Joi.boolean().optional()
       })
     ).required(),
     gainSiteReference: Joi.string().allow(''),

--- a/packages/webapp/src/utils/application.js
+++ b/packages/webapp/src/utils/application.js
@@ -373,8 +373,10 @@ const application = (session, account) => {
     applicationJson.landownerGainSiteRegistration.organisation = getOrganisation(session)
   }
 
-  // Filter blank files that are optional
-  applicationJson.landownerGainSiteRegistration.files = applicationJson.landownerGainSiteRegistration.files.filter(file => !(file.optional && !file.fileLocation))
+  // Filter blank files that are optional and remove the 'optional' property
+  applicationJson.landownerGainSiteRegistration.files = applicationJson.landownerGainSiteRegistration.files
+    .filter(file => !(file.optional && !file.fileLocation))
+    .map(({ optional, ...restOfFile }) => restOfFile)
 
   return applicationJson
 }

--- a/packages/webapp/src/utils/developer-application-validation.js
+++ b/packages/webapp/src/utils/developer-application-validation.js
@@ -53,7 +53,7 @@ const developerApplicationValidation = Joi.object({
       fileSize: Joi.number().required(),
       fileLocation: Joi.string().required(),
       fileName: Joi.string().required(),
-      optional: Joi.boolean().required()
+      optional: Joi.boolean().optional()
     })).required(),
     development: Joi.object({
       localPlanningAuthority: Joi.object({

--- a/packages/webapp/src/utils/developer-application.js
+++ b/packages/webapp/src/utils/developer-application.js
@@ -171,8 +171,10 @@ const application = (session, account) => {
     applicationJson.developerRegistration.agent = getClientDetails(session)
   }
 
-  // Filter blank files that are optional
-  applicationJson.developerRegistration.files = applicationJson.developerRegistration.files.filter(file => !(file.optional && !file.fileLocation))
+  // Filter blank files that are optional and remove the 'optional' property
+  applicationJson.developerRegistration.files = applicationJson.developerRegistration.files
+    .filter(file => !(file.optional && !file.fileLocation))
+    .map(({ optional, ...restOfFile }) => restOfFile)
 
   return applicationJson
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5077

An 'optional' property for files is appearing in the registration and allocation journey payloads, which does not match the agreed schema. This change filters out the property from the payloads by adding some additional logic to the application file.