### PR TITLE
BNGP-5286: Disable combined case start page

### DIFF
--- a/packages/webapp/src/routes/__tests__/manage-biodiversity-gains.spec.js
+++ b/packages/webapp/src/routes/__tests__/manage-biodiversity-gains.spec.js
@@ -4,6 +4,8 @@ import constants from '../../utils/constants.js'
 const url = constants.routes.MANAGE_BIODIVERSITY_GAINS
 const creditsPurchaseLink = '<a href="/credits-purchase/check-statutory-biodiversity-credits">Buy statutory biodiversity credits</a>'
 const combinedCaseLink = '<a href="/combined-case/combined-case-projects">Combined case projects</a>'
+const registerBiodiversityGainSitesLinkEnabled = '<a href="/land/start-register-gain-site">Register biodiversity gain sites</a>'
+const registerBiodiversityGainSitesLinkDisabled = '<a href="/land/biodiversity-gain-sites">Register biodiversity gain sites</a>'
 
 describe(url, () => {
   describe('GET', () => {
@@ -59,6 +61,18 @@ describe(url, () => {
       process.env.ENABLE_ROUTE_SUPPORT_FOR_COMBINED_CASE_JOURNEY = undefined
       const resp = await submitGetRequest({ url }, 200, { representing: 'Mock organisation', enableDev: false })
       expect(resp.payload).not.toContain(combinedCaseLink)
+    })
+
+    it('should render the link to start register gain site when enableCombinedCase is true', async () => {
+      process.env.ENABLE_ROUTE_SUPPORT_FOR_COMBINED_CASE_JOURNEY = 'Y'
+      const resp = await submitGetRequest({ url }, 200, { representing: 'Myself Mock user)', enableDev: true })
+      expect(resp.payload).toContain(registerBiodiversityGainSitesLinkEnabled)
+    })
+
+    it('should render the link to biodiversity gain sites when enableCombinedCase is false', async () => {
+      process.env.ENABLE_ROUTE_SUPPORT_FOR_COMBINED_CASE_JOURNEY = 'N'
+      const resp = await submitGetRequest({ url }, 200, { representing: 'Myself Mock user)', enableDev: false })
+      expect(resp.payload).toContain(registerBiodiversityGainSitesLinkDisabled)
     })
   })
 })

--- a/packages/webapp/src/views/manage-biodiversity-gains.html
+++ b/packages/webapp/src/views/manage-biodiversity-gains.html
@@ -23,7 +23,11 @@
           <div class="flex-container">
             <div class="dashboard-panel">
               <h2 class="govuk-heading-m govuk-!-padding-top-4">
+                {% if enableCombinedCase %}
                 <a href="/land/start-register-gain-site">Register biodiversity gain sites</a>
+                {% else %}
+                <a href="/land/biodiversity-gain-sites">Register biodiversity gain sites</a>
+                {% endif %}
               </h2>
               <p class="govuk-body-s">You can:</p>
               <ul class="govuk-list govuk-list--bullet govuk-body-s">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5286

This change disables the combined case start page if the ENABLE_ROUTE_SUPPORT_FOR_COMBINED_CASE_JOURNEY variable is set to "N". It does this by adding a check in the view page for the state of the environment variable and routing the user accordingly.