### PR TITLE
BNGP-5137: Combined case confirmation page

### DIFF
--- a/packages/webapp/src/plugins/on-post-handler.js
+++ b/packages/webapp/src/plugins/on-post-handler.js
@@ -89,6 +89,10 @@ const saveApplicationSession = async request => {
     applicationReferenceRedisKey = constants.redisKeys.DEVELOPER_APP_REFERENCE
   }
 
+  if (applicationType === constants.applicationTypes.COMBINED_CASE) {
+    applicationReferenceRedisKey = constants.redisKeys.COMBINED_CASE_APP_REFERENCE
+  }
+
   if (applicationType === constants.applicationTypes.CREDITS_PURCHASE) {
     applicationReferenceRedisKey = creditsPurchaseConstants.redisKeys.CREDITS_PURCHASE_APPLICATION_REFERENCE
   }
@@ -124,6 +128,7 @@ const isApplicationSessionSaveNeeded = request => {
     // Do not save application session data when an application has just been submitted.
     request?.response?.headers?.location !== constants.routes.APPLICATION_SUBMITTED &&
     request?.response?.headers?.location !== constants.routes.DEVELOPER_CONFIRMATION &&
+    request?.response?.headers?.location !== constants.routes.COMBINED_CASE_CONFIRMATION &&
     request?.response?.headers?.location !== creditsPurchaseConstants.routes.CREDITS_PURCHASE_CONFIRMATION &&
     request?.auth?.isAuthenticated
 }

--- a/packages/webapp/src/routes/__tests__/combined-case/application-submitted.spec.js
+++ b/packages/webapp/src/routes/__tests__/combined-case/application-submitted.spec.js
@@ -1,0 +1,44 @@
+import constants from '../../../utils/constants.js'
+import Session from '../../../__mocks__/session.js'
+import applicationSubmitted from '../../combined-case/application-submitted.js'
+
+const url = constants.routes.COMBINED_CASE_CONFIRMATION
+const combinedCaseReference = 'BNGREG-GB0688-ASK17'
+
+describe(url, () => {
+  describe('GET', () => {
+    it(`should render the ${url.substring(1)} view with combined case application reference`, async () => {
+      const getHandler = applicationSubmitted[0].handler
+      const session = new Session()
+      session.set(constants.redisKeys.COMBINED_CASE_APP_REFERENCE, combinedCaseReference)
+      let viewArgs = ''
+      const h = {
+        view: (...args) => {
+          viewArgs = args
+        }
+      }
+      await getHandler({ headers: { referer: 'http://localhost/combined-case/check-and-submit' }, yar: session }, h)
+      expect(viewArgs[0]).toEqual(constants.views.APPLICATION_SUBMITTED)
+    })
+
+    it('should render payment fee details', async () => {
+      const getHandler = applicationSubmitted[0].handler
+      const session = new Session()
+      session.set(constants.redisKeys.COMBINED_CASE_APP_REFERENCE, combinedCaseReference)
+      session.set('payment', {
+        caseType: 'combined-case',
+        fee: 600,
+        reference: combinedCaseReference,
+        type: 'BACS'
+      })
+      let viewArgs = ''
+      const h = {
+        view: (...args) => {
+          viewArgs = args
+        }
+      }
+      await getHandler({ headers: { referer: 'http://localhost/combined-case/check-and-submit' }, yar: session }, h)
+      expect(viewArgs[0]).toEqual(constants.views.APPLICATION_SUBMITTED)
+    })
+  })
+})

--- a/packages/webapp/src/routes/__tests__/combined-case/application-submitted.spec.js
+++ b/packages/webapp/src/routes/__tests__/combined-case/application-submitted.spec.js
@@ -19,6 +19,22 @@ describe(url, () => {
       }
       await getHandler({ headers: { referer: 'http://localhost/combined-case/check-and-submit' }, yar: session }, h)
       expect(viewArgs[0]).toEqual(constants.views.APPLICATION_SUBMITTED)
+      expect(viewArgs[1].applicationReference).toEqual(combinedCaseReference)
+    })
+
+    it(`should render the ${url.substring(1)} view with formatted sort code`, async () => {
+      const getHandler = applicationSubmitted[0].handler
+      const session = new Session()
+      session.set(constants.redisKeys.COMBINED_CASE_APP_REFERENCE, combinedCaseReference)
+      let viewArgs = ''
+      const h = {
+        view: (...args) => {
+          viewArgs = args
+        }
+      }
+      await getHandler({ headers: { referer: 'http://localhost/combined-case/check-and-submit' }, yar: session }, h)
+      expect(viewArgs[0]).toEqual(constants.views.APPLICATION_SUBMITTED)
+      expect(viewArgs[1].bacs.sortCode).toEqual('12 34 56')
     })
 
     it('should render payment fee details', async () => {

--- a/packages/webapp/src/routes/combined-case/application-submitted.js
+++ b/packages/webapp/src/routes/combined-case/application-submitted.js
@@ -1,0 +1,23 @@
+import constants from '../../utils/constants.js'
+import { getPayment } from '../../payment/payment-session.js'
+import bacs from '../../payment/bacs.js'
+
+const handlers = {
+  get: async (request, h) => {
+    const applicationReference = request.yar.get(constants.redisKeys.COMBINED_CASE_APP_REFERENCE)
+    const payment = getPayment(request.yar)
+    request.yar.reset()
+    request.yar.set(constants.redisKeys.COMBINED_CASE_APPLICATION_SUBMITTED, true)
+    return h.view(constants.views.APPLICATION_SUBMITTED, {
+      applicationReference,
+      payment,
+      bacs
+    })
+  }
+}
+
+export default [{
+  method: 'GET',
+  path: constants.routes.COMBINED_CASE_CONFIRMATION,
+  handler: handlers.get
+}]

--- a/packages/webapp/src/utils/combined-case-constants.js
+++ b/packages/webapp/src/utils/combined-case-constants.js
@@ -76,7 +76,8 @@ const routes = {
   COMBINED_CASE_PROJECTS: 'combined-case/combined-case-projects',
   COMBINED_CASE_CONTINUE_PROJECT: 'combined-case/continue-combined-case-project',
   COMBINED_CASE_NEW_PROJECT: 'combined-case/new-combined-case-project',
-  COMBINED_CASE_MATCH_HABITATS: 'combined-case/match-habitats'
+  COMBINED_CASE_MATCH_HABITATS: 'combined-case/match-habitats',
+  COMBINED_CASE_CONFIRMATION: 'combined-case/application-submitted'
 }
 
 const redisKeys = {
@@ -86,7 +87,9 @@ const redisKeys = {
   COMBINED_CASE_ALLOCATION_HABITATS_PROCESSING: 'combined-case-allocation-habitats-processing',
   COMBINED_CASE_REGISTRATION_HABITATS: 'combined-case-registration-habitats',
   COMBINED_CASE_SELECTED_HABITAT_ID: 'combined-case-selected-habitat-id',
-  COMBINED_CASE_MATCH_AVAILABLE_HABITATS_COMPLETE: 'combined-case-match-available-habitats-complete'
+  COMBINED_CASE_MATCH_AVAILABLE_HABITATS_COMPLETE: 'combined-case-match-available-habitats-complete',
+  COMBINED_CASE_APP_REFERENCE: 'combined-case-app-reference',
+  COMBINED_CASE_APPLICATION_SUBMITTED: 'combined-case-application-submitted'
 }
 
 const views = Object.fromEntries(


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5137

This change adds a confirmation page for the combined case journey. It does this by creating a new route and constants but reusing the common application-submitted view page.