### PR TITLE
BNGP-5362: Fix incorrect flow logic when changing from Check Your Answers

### DIFF
--- a/packages/webapp/src/journey-validation/shared/applicant-info.js
+++ b/packages/webapp/src/journey-validation/shared/applicant-info.js
@@ -236,96 +236,57 @@ const checkAppInfoRoute = (startUrl, nextUrl) => routeDefinition(
   }
 )
 
-const changeClientIndividualOrganisationRoute = (startUrl, nextUrl, nextUrl1) => routeDefinition(
+const changeRoute = (payloadKey, errorText, startUrl, nextUrlYes, nextUrlNo, additionalKeysToClear = []) => routeDefinition(
   startUrl,
   [],
   (session, request) => {
-    const { changeClientIndividualOrganisation } = request.payload
+    const changeValue = request.payload[payloadKey]
 
-    if (changeClientIndividualOrganisation === 'yes') {
-      request.yar.clear(constants.redisKeys.LANDOWNER_TYPE)
-      request.yar.clear(constants.redisKeys.CLIENT_INDIVIDUAL_ORGANISATION_KEY)
-      request.yar.clear(constants.redisKeys.IS_ADDRESS_UK_KEY)
-      request.yar.clear(constants.redisKeys.UK_ADDRESS_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_NAME_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_ORGANISATION_NAME_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_EMAIL_ADDRESS_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_PHONE_NUMBER_KEY)
-      request.yar.clear(constants.redisKeys.REFERER)
+    if (changeValue === 'yes') {
+      const keysToClear = [
+        constants.redisKeys.LANDOWNER_TYPE,
+        constants.redisKeys.CLIENT_INDIVIDUAL_ORGANISATION_KEY,
+        constants.redisKeys.IS_ADDRESS_UK_KEY,
+        constants.redisKeys.UK_ADDRESS_KEY,
+        constants.redisKeys.CLIENTS_NAME_KEY,
+        constants.redisKeys.CLIENTS_ORGANISATION_NAME_KEY,
+        constants.redisKeys.CLIENTS_EMAIL_ADDRESS_KEY,
+        constants.redisKeys.CLIENTS_PHONE_NUMBER_KEY,
+        constants.redisKeys.REFERER,
+        ...additionalKeysToClear
+      ]
 
-      return nextUrl
-    } else if (changeClientIndividualOrganisation === 'no') {
-      return nextUrl1
-    } else {
-      const message = 'Select yes if you want to change whether your client is an individual or organisation'
-      throw new FormError(message, {
-        text: message,
-        href: '#changeClientIndividualOrganisation'
-      })
+      keysToClear.forEach(key => request.yar.clear(key))
+
+      return nextUrlYes
     }
+
+    if (changeValue === 'no') {
+      const referrerUrl = getValidReferrerUrl(session, ['/combined-case/check-and-submit', '/land/check-and-submit'])
+      return referrerUrl || nextUrlNo
+    }
+
+    throw new FormError(errorText, {
+      text: errorText,
+      href: `#${payloadKey}`
+    })
   }
 )
 
-const changeActingOnBehalfOfClientRoute = (startUrl, nextUrl, nextUrl1) => routeDefinition(
-  startUrl,
-  [],
-  (session, request) => {
-    const { changeActingOnBehalfOfClient } = request.payload
+const changeClientIndividualOrganisationRoute = (startUrl, nextUrlYes, nextUrlNo) =>
+  changeRoute('changeClientIndividualOrganisation',
+    'Select yes if you want to change whether your client is an individual or organisation',
+    startUrl, nextUrlYes, nextUrlNo)
 
-    if (changeActingOnBehalfOfClient === 'yes') {
-      request.yar.clear(constants.redisKeys.IS_AGENT)
-      request.yar.clear(constants.redisKeys.LANDOWNER_TYPE)
-      request.yar.clear(constants.redisKeys.CLIENT_INDIVIDUAL_ORGANISATION_KEY)
-      request.yar.clear(constants.redisKeys.IS_ADDRESS_UK_KEY)
-      request.yar.clear(constants.redisKeys.UK_ADDRESS_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_NAME_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_ORGANISATION_NAME_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_EMAIL_ADDRESS_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_PHONE_NUMBER_KEY)
-      request.yar.clear(constants.redisKeys.REFERER)
+const changeActingOnBehalfOfClientRoute = (startUrl, nextUrlYes, nextUrlNo) =>
+  changeRoute('changeActingOnBehalfOfClient',
+    'Select yes if you want to change whether you’re acting on behalf of a client',
+    startUrl, nextUrlYes, nextUrlNo, [constants.redisKeys.IS_AGENT])
 
-      return nextUrl
-    } else if (changeActingOnBehalfOfClient === 'no') {
-      return nextUrl1
-    } else {
-      const message = 'Select yes if you want to change whether you’re acting on behalf of a client'
-      throw new FormError(message, {
-        text: message,
-        href: '#changeActingOnBehalfOfClient'
-      })
-    }
-  }
-)
-
-const changeApplyingIndividualOrg = (startUrl, nextUrl, nextUrl1) => routeDefinition(
-  startUrl,
-  [],
-  (session, request) => {
-    const { changeApplyingIndividualOrganisation } = request.payload
-
-    if (changeApplyingIndividualOrganisation === 'yes') {
-      request.yar.clear(constants.redisKeys.LANDOWNER_TYPE)
-      request.yar.clear(constants.redisKeys.CLIENT_INDIVIDUAL_ORGANISATION_KEY)
-      request.yar.clear(constants.redisKeys.IS_ADDRESS_UK_KEY)
-      request.yar.clear(constants.redisKeys.UK_ADDRESS_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_NAME_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_ORGANISATION_NAME_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_EMAIL_ADDRESS_KEY)
-      request.yar.clear(constants.redisKeys.CLIENTS_PHONE_NUMBER_KEY)
-      request.yar.clear(constants.redisKeys.REFERER)
-
-      return nextUrl
-    } else if (changeApplyingIndividualOrganisation === 'no') {
-      return nextUrl1
-    } else {
-      const message = 'Select yes if you want to change whether you’re applying as an individual or an organisation'
-      throw new FormError(message, {
-        text: message,
-        href: '#changeApplyingIndividualOrganisation'
-      })
-    }
-  }
-)
+const changeApplyingIndividualOrg = (startUrl, nextUrlYes, nextUrlNo) =>
+  changeRoute('changeApplyingIndividualOrganisation',
+    'Select yes if you want to change whether you’re applying as an individual or an organisation',
+    startUrl, nextUrlYes, nextUrlNo)
 
 export {
   createAgentActingForClientRoute,

--- a/packages/webapp/src/journey-validation/shared/applicant-info.js
+++ b/packages/webapp/src/journey-validation/shared/applicant-info.js
@@ -231,8 +231,9 @@ const clientsPhoneNumberRoute = (startUrl, nextUrl) => routeDefinition(
 const checkAppInfoRoute = (startUrl, nextUrl) => routeDefinition(
   startUrl,
   [],
-  () => {
-    return nextUrl
+  (session) => {
+    const checkAndSubmitJourneyRoute = session.get(constants.redisKeys.CHECK_AND_SUBMIT_JOURNEY_ROUTE)
+    return checkAndSubmitJourneyRoute || nextUrl
   }
 )
 

--- a/packages/webapp/src/journey-validation/shared/legal-agreement.js
+++ b/packages/webapp/src/journey-validation/shared/legal-agreement.js
@@ -269,8 +269,9 @@ const checkPlanningAuthoritiesRoute = (startUrl, nextUrl, altNextUrl) => routeDe
 const checkLegalAgreementDetailsRoute = (startUrl, nextUrl) => routeDefinition(
   startUrl,
   [],
-  () => {
-    return nextUrl
+  (session) => {
+    const checkAndSubmitJourneyRoute = session.get(constants.redisKeys.CHECK_AND_SUBMIT_JOURNEY_ROUTE)
+    return checkAndSubmitJourneyRoute || nextUrl
   }
 )
 

--- a/packages/webapp/src/routes/combined-case/check-and-submit.js
+++ b/packages/webapp/src/routes/combined-case/check-and-submit.js
@@ -21,6 +21,8 @@ const handlers = {
       return h.redirect(constants.routes.COMBINED_CASE_TASK_LIST)
     }
 
+    request.yar.set(constants.redisKeys.CHECK_AND_SUBMIT_JOURNEY_ROUTE, constants.routes.COMBINED_CASE_CHECK_AND_SUBMIT)
+
     const applicationDetails = application(request.yar, request.auth.credentials.account).combinedCase
     console.log(JSON.stringify(applicationDetails, null, 2))
     const claims = request.auth.credentials.account.idTokenClaims

--- a/packages/webapp/src/routes/combined-case/check-and-submit.js
+++ b/packages/webapp/src/routes/combined-case/check-and-submit.js
@@ -24,7 +24,6 @@ const handlers = {
     request.yar.set(constants.redisKeys.CHECK_AND_SUBMIT_JOURNEY_ROUTE, constants.routes.COMBINED_CASE_CHECK_AND_SUBMIT)
 
     const applicationDetails = application(request.yar, request.auth.credentials.account).combinedCase
-    console.log(JSON.stringify(applicationDetails, null, 2))
     const claims = request.auth.credentials.account.idTokenClaims
     const { currentOrganisation } = getOrganisationDetails(claims)
     return h.view(

--- a/packages/webapp/src/routes/combined-case/tasklist.js
+++ b/packages/webapp/src/routes/combined-case/tasklist.js
@@ -8,6 +8,8 @@ const handlers = {
 
     const { taskList, totalTasks, completedTasks, canSubmit } = getTaskList(constants.applicationTypes.COMBINED_CASE, request.yar)
 
+    request.yar.clear(constants.redisKeys.CHECK_AND_SUBMIT_JOURNEY_ROUTE)
+
     return h.view(constants.views.COMBINED_CASE_TASK_LIST, {
       canSubmit,
       completedTasks,

--- a/packages/webapp/src/routes/land/check-and-submit.js
+++ b/packages/webapp/src/routes/land/check-and-submit.js
@@ -9,25 +9,27 @@ import getRegistrationDetails from '../../utils/get-land-check-and-submit-detail
 const handlers = {
   get: async (request, h) => {
     const appSubmitted = request.yar.get(constants.redisKeys.LAND_APPLICATION_SUBMITTED)
-
     if (appSubmitted) {
       return h.redirect(constants.routes.MANAGE_BIODIVERSITY_GAINS)
     }
 
     const { canSubmit } = getTaskList(constants.applicationTypes.REGISTRATION, request.yar)
-
     if (!canSubmit) {
       return h.redirect(constants.routes.REGISTER_LAND_TASK_LIST)
     }
 
+    const applicationReference = request.yar.get(constants.redisKeys.APPLICATION_REFERENCE)
+    if (applicationReference === undefined || applicationReference === null) {
+      return h.redirect('/')
+    }
+
+    request.yar.set(constants.redisKeys.CHECK_AND_SUBMIT_JOURNEY_ROUTE, constants.routes.CHECK_AND_SUBMIT)
+
     const applicationDetails = application(request.yar, request.auth.credentials.account).landownerGainSiteRegistration
 
-    return request.yar.get(constants.redisKeys.APPLICATION_REFERENCE) !== undefined &&
-      request.yar.get(constants.redisKeys.APPLICATION_REFERENCE) !== null
-      ? h.view(constants.views.CHECK_AND_SUBMIT,
-        getRegistrationDetails(request, applicationDetails)
-      )
-      : h.redirect('/')
+    return h.view(constants.views.CHECK_AND_SUBMIT,
+      getRegistrationDetails(request, applicationDetails)
+    )
   },
   post: async (request, h) => {
     if (request.payload.termsAndConditionsConfirmed !== 'Yes') {

--- a/packages/webapp/src/routes/land/register-land-task-list.js
+++ b/packages/webapp/src/routes/land/register-land-task-list.js
@@ -5,6 +5,8 @@ const handlers = {
   get: async (request, h) => {
     const { taskList, totalTasks, completedTasks, canSubmit } = getTaskList(constants.applicationTypes.REGISTRATION, request.yar)
 
+    request.yar.clear(constants.redisKeys.CHECK_AND_SUBMIT_JOURNEY_ROUTE)
+
     return h.view(constants.views.REGISTER_LAND_TASK_LIST, {
       registrationTasks: { taskList },
       registrationCompletedTasks: completedTasks,

--- a/packages/webapp/src/utils/loj-constants.js
+++ b/packages/webapp/src/utils/loj-constants.js
@@ -136,6 +136,7 @@ const FULL_NAME = 'fullname'
 const LEGAL_AGREEMENT_LANDOWNER_CONSERVATION_CONVENANTS = 'legal-agreement-landowner-conservation-convenants'
 const LANDOWNERS = 'landowners'
 const REFERER = 'referer'
+const CHECK_AND_SUBMIT_JOURNEY_ROUTE = 'check-and-submit-journey-route'
 const EMAIL_VALUE = 'email-value'
 const GEOSPATIAL_UPLOAD_TYPE = 'geospatial-land-boundary'
 const LEGAL_AGREEMENT_UPLOAD_TYPE = 'legal-agreement'
@@ -261,6 +262,7 @@ export default {
     HABITAT_ENHANCEMENTS_END_DATE_OPTION,
     METRIC_UPLOADED_ANSWER,
     REFERER,
+    CHECK_AND_SUBMIT_JOURNEY_ROUTE,
     EMAIL_VALUE,
     LANDOWNER_TYPE,
     DEFRA_ACCOUNT_DETAILS_CONFIRMED,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5362

Once a user has gone through the "register land" or "combined case" journey and arrived at the Check Your Answers page, there is an issue with some of the Change sections where users are incorrectly returned to the task list instead of Check Your Answers after completing a journey.

The Change links for the following options present the user with an "Are you sure you want to change...?" page:

- Acting on behalf of a client
- Client is an individual or organisation
- Applicant is an individual or an organisation

(Note that "Type of legal agreement" also presents the user with 

If the user selects "No", we would expect them to be returned to Check Your Answers. Instead, they are shown a mini Check Your Answers page, and continuing from there takes the user back to the task list.

If the user selects "Yes", we would expect them to be presented with a series of questions, followed by a mini Check Your Answers page, and then be returned to Check Your Answers. Instead, they go through the questions, are presented with a mini Check Your Answers page, and continuing from there takes the user back to the task list.

This PR fixes these in two ways:

- To fix the "No" scenario, we check to see if the referrer is a Check Your Answers page; if so, they are returned there. Otherwise, we proceed to the referrer or next url as before.
- To fix the "Yes" scenario, we can't rely on the referrer since it is cleared in some scenarios. We therefore introduce a new Redis key `CHECK_AND_SUBMIT_JOURNEY_ROUTE`. When the user visits a Check Your Answers page the key is set to the page's url. The mini Check Your Answers pages have their logic amended to use this url if one is set.