### PR TITLE
BNGP-5357: Metric file should not delete until new upload

### DIFF
--- a/packages/webapp/src/routes/__tests__/combined-case/check-allocation-metric.spec.js
+++ b/packages/webapp/src/routes/__tests__/combined-case/check-allocation-metric.spec.js
@@ -76,15 +76,8 @@ describe(url, () => {
               viewResult = view
             }
           }
-          const { blobStorageConnector } = require('@defra/bng-connectors-lib')
-          const spy = jest.spyOn(blobStorageConnector, 'deleteBlobIfExists')
           await checkMetricFile.default[1].handler(request, h)
           expect(viewResult).toEqual(constants.routes.COMBINED_CASE_UPLOAD_ALLOCATION_METRIC)
-          expect(spy).toHaveBeenCalledWith({
-            containerName: 'customer-uploads',
-            blobName: mockFileLocation
-          })
-          expect(spy).toHaveBeenCalledTimes(1)
           done()
         } catch (err) {
           done(err)

--- a/packages/webapp/src/routes/__tests__/developer/check-metric-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/developer/check-metric-file.spec.js
@@ -83,15 +83,9 @@ describe(url, () => {
               viewResult = view
             }
           }
-          const { blobStorageConnector } = require('@defra/bng-connectors-lib')
-          const spy = jest.spyOn(blobStorageConnector, 'deleteBlobIfExists')
           await checkMetricFile.default[1].handler(request, h)
+
           expect(viewResult).toEqual(constants.routes.DEVELOPER_BNG_NUMBER)
-          expect(spy).toHaveBeenCalledWith({
-            containerName: 'customer-uploads',
-            blobName: mockFileLocation
-          })
-          expect(spy).toHaveBeenCalledTimes(1)
           done()
         } catch (err) {
           done(err)

--- a/packages/webapp/src/utils/helpers.js
+++ b/packages/webapp/src/utils/helpers.js
@@ -5,7 +5,6 @@ import Joi from 'joi'
 import constants from './constants.js'
 import validator from 'email-validator'
 import habitatTypeMap from './habitatTypeMap.js'
-import { deleteBlobFromContainers } from './azure-storage.js'
 
 const isoDateFormat = 'YYYY-MM-DD'
 const postcodeRegExp = /^([A-Za-z][A-Ha-hJ-Yj-y]?\d[A-Za-z0-9]? ?\d[A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/ // https://stackoverflow.com/a/51885364
@@ -812,12 +811,6 @@ const checkDeveloperUploadMetric = async (request, h, noRedirectRoute, yesRedire
   request.yar.set(constants.redisKeys.DEVELOPER_METRIC_FILE_CHECKED, checkUploadMetric)
 
   if (checkUploadMetric === constants.CHECK_UPLOAD_METRIC_OPTIONS.NO) {
-    await deleteBlobFromContainers(metricUploadLocation)
-    request.yar.clear(constants.redisKeys.DEVELOPER_METRIC_LOCATION)
-    request.yar.clear(constants.redisKeys.BIODIVERSITY_NET_GAIN_NUMBER)
-    request.yar.clear(constants.redisKeys.DEVELOPER_OFF_SITE_GAIN_CONFIRMED)
-    request.yar.clear(constants.redisKeys.COMBINED_CASE_ALLOCATION_HABITATS)
-    request.yar.clear(constants.redisKeys.COMBINED_CASE_MATCH_AVAILABLE_HABITATS_COMPLETE)
     return h.redirect(noRedirectRoute)
   } else if (checkUploadMetric === constants.CHECK_UPLOAD_METRIC_OPTIONS.YES) {
     return h.redirect(yesRedirectRoute)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5357

This change fixes a bug that prematurely deletes the metric file data. We fix this by removing the deletion logic from the checkDeveloperUploadMetric function and moving it to the uploadAllocationMetric post request.