### PR TITLE
BNGP-5422: Fix combined case back button redirecting to land task list

### DIFF
--- a/packages/webapp/src/routes/__tests__/land/check-legal-agreement-details.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-legal-agreement-details.spec.js
@@ -49,7 +49,7 @@ describe('Legal Agreement controller tests', () => {
       })
     })
 
-    it(`should render the ${url.substring(1)} view with some of the missing data`, done => {
+    it('should redirect to REGISTER_LAND_TASK_LIST view if mandatory data missing', done => {
       jest.isolateModules(async () => {
         try {
           const legalAgreementDetails = require('../../land/check-legal-agreement-details.js')
@@ -69,6 +69,36 @@ describe('Legal Agreement controller tests', () => {
           }
           await legalAgreementDetails.default[0].handler(request, h)
           expect(redirectArgs).toEqual([constants.routes.REGISTER_LAND_TASK_LIST])
+          done()
+        } catch (err) {
+          done(err)
+        }
+      })
+    })
+
+    it('should redirect to COMBINED_CASE_TASK_LIST view if a combined case application and mandatory data is missing', done => {
+      jest.isolateModules(async () => {
+        try {
+          const legalAgreementDetails = require('../../land/check-legal-agreement-details.js')
+          redisMap.set(constants.redisKeys.LEGAL_AGREEMENT_FILES, undefined)
+          let redirectArgs = ''
+          const request = {
+            yar: redisMap,
+            _route: {
+              path: '/combined-case/check-legal-agreement-details'
+            }
+          }
+          redisMap.set(constants.redisKeys.HABITAT_PLAN_LEGAL_AGREEMENT_DOCUMENT_INCLUDED_YES_NO, 'No')
+          redisMap.set(constants.redisKeys.HABITAT_PLAN_LOCATION, undefined)
+          redisMap.set(constants.redisKeys.ENHANCEMENT_WORKS_START_DATE_KEY, null)
+          redisMap.set(constants.redisKeys.HABITAT_ENHANCEMENTS_END_DATE_KEY, null)
+          const h = {
+            redirect: (...args) => {
+              redirectArgs = args
+            }
+          }
+          await legalAgreementDetails.default[0].handler(request, h)
+          expect(redirectArgs).toEqual([constants.routes.COMBINED_CASE_TASK_LIST])
           done()
         } catch (err) {
           done(err)

--- a/packages/webapp/src/routes/__tests__/land/check-metric-details.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-metric-details.spec.js
@@ -52,6 +52,32 @@ describe(url, () => {
         }
       })
     })
+    it('should redirect to COMBINED_CASE_TASK_LIST view if a combined case application and mandatory data is missing', done => {
+      jest.isolateModules(async () => {
+        try {
+          const getHandler = checkMetricDetails[0].handler
+          const redisMap = new Map()
+          redisMap.set(constants.redisKeys.METRIC_LOCATION, undefined)
+          let redirectArgs = ''
+          const request = {
+            yar: redisMap,
+            _route: {
+              path: '/combined-case/check-metric-details'
+            }
+          }
+          const h = {
+            redirect: (...args) => {
+              redirectArgs = args
+            }
+          }
+          await getHandler(request, h)
+          expect(redirectArgs).toEqual([constants.routes.COMBINED_CASE_TASK_LIST])
+          done()
+        } catch (err) {
+          done(err)
+        }
+      })
+    })
   })
   describe('POST', () => {
     it('Should flow to register task list', async () => {

--- a/packages/webapp/src/routes/__tests__/land/check-ownership-proof-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-ownership-proof-file.spec.js
@@ -99,6 +99,21 @@ describe(url, () => {
 
       expect(viewResult).toEqual(constants.routes.REGISTER_LAND_TASK_LIST)
     })
+
+    it('should redirect to the combined case task list if this is a combined case application and required data is not found', async () => {
+      redisMap.set(constants.redisKeys.LAND_OWNERSHIP_PROOFS, [])
+      const request = {
+        yar: redisMap,
+        query: { id: '2' },
+        _route: {
+          path: '/combined-case/check-ownership-proof-file'
+        }
+      }
+
+      await checkOwnershipProofFile[0].handler(request, h)
+
+      expect(viewResult).toEqual(constants.routes.COMBINED_CASE_TASK_LIST)
+    })
   })
 
   describe('POST', () => {

--- a/packages/webapp/src/routes/land/check-legal-agreement-details.js
+++ b/packages/webapp/src/routes/land/check-legal-agreement-details.js
@@ -16,8 +16,8 @@ import { getIndividualTaskStatus, getNextStep } from '../../journey-validation/t
 const handlers = {
   get: async (request, h) => {
     const registrationTaskStatus = getIndividualTaskStatus(request.yar, REGISTRATIONCONSTANTS.LEGAL_AGREEMENT)
-    const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
     if (registrationTaskStatus !== 'COMPLETED') {
+      const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
       return isCombinedCase
         ? h.redirect(constants.routes.COMBINED_CASE_TASK_LIST)
         : h.redirect(constants.routes.REGISTER_LAND_TASK_LIST)

--- a/packages/webapp/src/routes/land/check-legal-agreement-details.js
+++ b/packages/webapp/src/routes/land/check-legal-agreement-details.js
@@ -16,8 +16,11 @@ import { getIndividualTaskStatus, getNextStep } from '../../journey-validation/t
 const handlers = {
   get: async (request, h) => {
     const registrationTaskStatus = getIndividualTaskStatus(request.yar, REGISTRATIONCONSTANTS.LEGAL_AGREEMENT)
+    const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
     if (registrationTaskStatus !== 'COMPLETED') {
-      return h.redirect(constants.routes.REGISTER_LAND_TASK_LIST)
+      return isCombinedCase
+        ? h.redirect(constants.routes.COMBINED_CASE_TASK_LIST)
+        : h.redirect(constants.routes.REGISTER_LAND_TASK_LIST)
     }
     return h.view(constants.views.CHECK_LEGAL_AGREEMENT_DETAILS, {
       listArray,

--- a/packages/webapp/src/routes/land/check-metric-details.js
+++ b/packages/webapp/src/routes/land/check-metric-details.js
@@ -5,11 +5,13 @@ import { getIndividualTaskStatus, getNextStep } from '../../journey-validation/t
 const handlers = {
   get: async (request, h) => {
     const registrationTaskStatus = getIndividualTaskStatus(request.yar, REGISTRATIONCONSTANTS.HABITAT_INFO)
+    const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
     if (registrationTaskStatus !== 'COMPLETED') {
-      return h.redirect(constants.routes.REGISTER_LAND_TASK_LIST)
+      return isCombinedCase
+        ? h.redirect(constants.routes.COMBINED_CASE_TASK_LIST)
+        : h.redirect(constants.routes.REGISTER_LAND_TASK_LIST)
     }
     const metricUploadLocation = request.yar.get(constants.redisKeys.METRIC_LOCATION)
-    const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
     return h.view(constants.views.CHECK_METRIC_DETAILS, {
       filename: path.basename(metricUploadLocation),
       urlPath: isCombinedCase ? '/combined-case' : '/land'

--- a/packages/webapp/src/routes/land/check-ownership-proof-file.js
+++ b/packages/webapp/src/routes/land/check-ownership-proof-file.js
@@ -7,8 +7,8 @@ import { getNextStep } from '../../journey-validation/task-list-generator.js'
 const handlers = {
   get: async (request, h) => {
     const context = getContext(request)
-    const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
     if (!context.fileName || !context.fileSize) {
+      const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
       return isCombinedCase
         ? h.redirect(constants.routes.COMBINED_CASE_TASK_LIST)
         : h.redirect(constants.routes.REGISTER_LAND_TASK_LIST)

--- a/packages/webapp/src/routes/land/check-ownership-proof-file.js
+++ b/packages/webapp/src/routes/land/check-ownership-proof-file.js
@@ -7,8 +7,11 @@ import { getNextStep } from '../../journey-validation/task-list-generator.js'
 const handlers = {
   get: async (request, h) => {
     const context = getContext(request)
+    const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
     if (!context.fileName || !context.fileSize) {
-      return h.redirect(constants.routes.REGISTER_LAND_TASK_LIST)
+      return isCombinedCase
+        ? h.redirect(constants.routes.COMBINED_CASE_TASK_LIST)
+        : h.redirect(constants.routes.REGISTER_LAND_TASK_LIST)
     }
     return h.view(constants.views.CHECK_PROOF_OF_OWNERSHIP, context)
   },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5422

Some pages are shared between the `/land` and `/combined-case` journeys. If mandatory data is missing when the page is accessed, the user is redirected to the `/land` task list, regardless of whether they were completing a `/land` or a `/combined-case` application. If they then try to go back into that section from the `/land` task list and attempt to complete it, a 500 error will be thrown.

We fixed this for `/combined-case/check-applicant-information` in [a previous PR](https://github.com/DEFRA/biodiversity-net-gain-service/pull/849); we've since identified 3 more pages with this issue so we resolve them in this PR:

```
/combined-case/check-legal-agreement-details
/combined-case/check-metric-details
/combined-case/check-ownership-proof-file
```