### PR TITLE
BNGP-5359: Content fixes v4

### DIFF
--- a/packages/webapp/src/views/common/upload-written-authorisation.html
+++ b/packages/webapp/src/views/common/upload-written-authorisation.html
@@ -2,8 +2,15 @@
 
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% set pageHeading = "Upload written authorisation to apply" %}
+
+{% if isIndividual %}
+  {% set clientOrOrganisationName = clientsName.value.firstName + " " + clientsName.value.lastName %}
+{% else %}
+  {% set clientOrOrganisationName = clientsOrganisationName %}
+{% endif %}
 
 {% block formContent %}
     <div class="govuk-body">
@@ -30,7 +37,7 @@
                     {% else %}
                     <b>{{ clientsOrganisationName }}'s</b>
                     {% endif %}
-                    authorisation for you to act on their behalf
+                    authorisation for you to act on their behalf, dated within the last 2 months
                   </li>
                   {% if isIndividual %}
                     <li>their name and signature</li>
@@ -55,24 +62,15 @@
                     }
                 }) }}
 
-                <details class="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      What to do if you have no written authorisation
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <p>You can <a href="#">download an 'Authorise an agent' form</a> and ask 
-                      <strong>                    
-                        {% if isIndividual %}
-                          {{ clientsName.value.firstName }} {{ clientsName.value.lastName }}
-                        {% else %}
-                          {{ clientsOrganisationName }}
-                        {% endif %}
-                      </strong> to complete it.</p>
+                {{ govukInsetText({
+                  html: "
+                    <h3>What to do if you have no written authorisation</h3>
+                    <p>You can <a href='https://www.gov.uk/government/publications/authorise-an-agent-to-act-your-behalf-form' target='_blank'>download an 'Authorise an agent' form (opens in new tab)</a> and ask
+                      <strong>" + clientOrOrganisationName + "</strong> to complete it.
+                    </p>
                     <p>You can then come back to this application and upload the completed form as written authorisation to apply.</p>
-                  </div>
-                </details>
+                  "
+                }) }}
 
                 {{ govukButton({
                     text: "Upload",

--- a/packages/webapp/src/views/land/check-applicant-information.html
+++ b/packages/webapp/src/views/land/check-applicant-information.html
@@ -20,7 +20,7 @@
 
         <form method="post">
           {{ govukButton({
-            text: "Continue",
+            text: "Save and continue",
             attributes: {
                 id: "continue",
                 "data-testid": "continue"

--- a/packages/webapp/src/views/land/legal-agreement-type.html
+++ b/packages/webapp/src/views/land/legal-agreement-type.html
@@ -1,5 +1,6 @@
 {% extends 'form-layout.html' %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% set pageHeading = "Which legal agreement do you have?" %}
 
 {% block formContent %}
@@ -41,9 +42,17 @@
               }
             ]
         }) }}
-        <p class="govuk-!-padding-top-3">
-          <a href="/land/need-legal-agreement">I do not have a legal agreement</a>
-        </p>
+        {{ govukDetails({
+            summaryText: "What to do if you have no legal agreement",
+            html: "
+                <p>You need to upload a legal agreement.</p>
+                <p>This must be either a:</p>
+                <ul class='govuk-list govuk-list--bullet'>
+                    <li><a href='https://www.gov.uk/guidance/getting-and-using-a-conservation-covenant-agreement'>conservation covenant</a></li>
+                    <li><a href='https://www.gov.uk/guidance/planning-obligations'>planning obligation (Section 106 agreement)</a></li>
+                </ul>
+            "
+        }) }}
         {{ govukButton({
             text: 'Continue',
             attributes: {

--- a/packages/webapp/src/views/land/upload-habitat-plan.html
+++ b/packages/webapp/src/views/land/upload-habitat-plan.html
@@ -31,13 +31,16 @@
               classes: "govuk-visually-hidden"
             }
           }) }}
-          {{ govukButton({
-            text: "Upload",
-            attributes: {
-              id: "continue",
-              "data-testid": "continue"
-            }
-          }) }}
+          <div class="govuk-button-group">
+            {{ govukButton({
+              text: "Save and upload",
+              attributes: {
+                id: "continue",
+                "data-testid": "continue"
+              }
+            }) }}
+            <a class="govuk-link" href="/signout">Or save progress and come back later</a>
+          </div>
       </div>
     </div>
   </div>

--- a/packages/webapp/src/views/land/upload-habitat-plan.html
+++ b/packages/webapp/src/views/land/upload-habitat-plan.html
@@ -38,7 +38,6 @@
               "data-testid": "continue"
             }
           }) }}
-          <p><a href="/land/need-habitat-plan">I do not have the habitat management and monitoring plan</a></p>
       </div>
     </div>
   </div>

--- a/packages/webapp/src/views/land/upload-land-boundary.html
+++ b/packages/webapp/src/views/land/upload-land-boundary.html
@@ -34,13 +34,16 @@
             }
           }) }}
 
-          {{ govukButton({
-            text: "Upload",
-            attributes: {
-              id: "continue",
-              "data-testid": "continue"
-            }
-          }) }}
+          <div class="govuk-button-group">
+            {{ govukButton({
+              text: "Save and upload",
+              attributes: {
+                id: "continue",
+                "data-testid": "continue"
+              }
+            }) }}
+            <a class="govuk-link" href="/signout">Or save progress and come back later</a>
+          </div>
       </div>
     </div>
   </div>

--- a/packages/webapp/src/views/land/upload-land-boundary.html
+++ b/packages/webapp/src/views/land/upload-land-boundary.html
@@ -17,7 +17,8 @@
         </h1>
 
         <div id="location-upload-hint">
-          <p>The file should be:</p>
+          <p>This should show the boundary of the land you want to register as a biodiversity gain site.</p>
+          <p>The file should be:</p> 
           <ul class="govuk-list govuk-list--bullet">
             <li>a DOC, DOCX, JPG, PNG or PDF</li>
             <li>no larger than 50MB</li>
@@ -32,9 +33,7 @@
               classes: "govuk-visually-hidden"
             }
           }) }}
-          <p class="govuk-!-padding-top-3">
-            <a href="/land/need-boundary-file">I do not have a file showing the boundary of the biodiversity gain site</a>
-          </p>
+
           {{ govukButton({
             text: "Upload",
             attributes: {

--- a/packages/webapp/src/views/land/upload-legal-agreement.html
+++ b/packages/webapp/src/views/land/upload-legal-agreement.html
@@ -52,13 +52,16 @@
             "
           }) }}
 
-          {{ govukButton({
-            text: "Upload",
-            attributes: {
-              id: "continue",
-              "data-testid": "continue"
-            }
-          }) }}
+          <div class="govuk-button-group">
+            {{ govukButton({
+              text: "Save and upload",
+              attributes: {
+                id: "continue",
+                "data-testid": "continue"
+              }
+            }) }}
+            <a class="govuk-link" href="/signout">Or save progress and come back later</a>
+          </div>
       </div>
     </div>
   </div>

--- a/packages/webapp/src/views/land/upload-legal-agreement.html
+++ b/packages/webapp/src/views/land/upload-legal-agreement.html
@@ -1,7 +1,9 @@
 {% extends 'multipart-form-layout.html' %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% set pageHeading = "Upload the " + legalAgreementType %}
+{% set summaryText = "What to do if you have no " + legalAgreementType %}
 
 {% block formContent %}
   <div class="govuk-body">
@@ -33,9 +35,23 @@
               classes: "govuk-visually-hidden"
             }
           }) }}
-          <p class="govuk-!-padding-top-3">
-            <a href="/land/need-legal-agreement">I do not have a {{legalAgreementType}}</a>
-          </p>
+
+          {{ govukDetails({
+            summaryText: "What to do if you have no legal agreement",
+            html: "
+            <p>You need to upload a legal agreement that:</p>
+            <ul class='govuk-list govuk-list--bullet'>
+              <li>secures the habitat enhancements on the land</li>
+              <li>is for at least 30 years</li>
+            </ul>
+            <p>This must be either a:</p>
+            <ul class='govuk-list govuk-list--bullet'>
+              <li><a href='https://www.gov.uk/guidance/getting-and-using-a-conservation-covenant-agreement'>conservation covenant</a></li>
+              <li><a href='https://www.gov.uk/guidance/planning-obligations'>planning obligation (Section 106 agreement)</a></li>
+            </ul>
+            "
+          }) }}
+
           {{ govukButton({
             text: "Upload",
             attributes: {

--- a/packages/webapp/src/views/land/upload-local-land-charge.html
+++ b/packages/webapp/src/views/land/upload-local-land-charge.html
@@ -20,7 +20,10 @@
               isPageHeading: true
             }
           }) }}
-          <p>This is a certificate that shows the legal agreement has been registered with the local planning authority.</p>
+          <p>
+            This is a certificate that shows the legal agreement has been registered with the local planning authority (LPA).
+            You must upload the <a href="https://www.gov.uk/search-local-land-charges" target="_blank">official search certificate</a> from HM Land Registry or your LPA, dated within the last 2 months.
+          </p>
           <p>The file should be:</p>
           
       <ul class="govuk-list govuk-list--bullet">
@@ -32,7 +35,7 @@
             id: "localLandChargeCertificate.",
             name: "localLandChargeCertificate",
             errorMessage: err[0],
-           
+
             label: {
               text: "Choose file",
               classes: "govuk-visually-hidden"
@@ -46,7 +49,6 @@
               "data-testid": "continue"
             }
           }) }}
-          <p><a href="/land/need-local-land-charge">I do not have a local land charge search certificate</a></p>
       </div>
     </div>
   </div>

--- a/packages/webapp/src/views/land/upload-local-land-charge.html
+++ b/packages/webapp/src/views/land/upload-local-land-charge.html
@@ -42,13 +42,16 @@
             }
           }) }}
 
-          {{ govukButton({
-            text: "Upload",
-            attributes: {
-              id: "continue",
-              "data-testid": "continue"
-            }
-          }) }}
+          <div class="govuk-button-group">
+            {{ govukButton({
+              text: "Save and upload",
+              attributes: {
+                id: "continue",
+                "data-testid": "continue"
+              }
+            }) }}
+            <a class="govuk-link" href="/signout">Or save progress and come back later</a>
+          </div>
       </div>
     </div>
   </div>

--- a/packages/webapp/src/views/land/upload-metric.html
+++ b/packages/webapp/src/views/land/upload-metric.html
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
-{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% set pageHeading = "Upload the statutory biodiversity metric calculations for the biodiversity gain site" %}
 
 {% block formContent %}
@@ -15,6 +14,13 @@
         <h1 class="govuk-heading-l">
           {{ pageHeading }}
         </h1>
+        <p>
+          You must upload a calculation made using the statutory (official) biodiversity metric tool for the site you want to register.
+          Do not use previous versions of the metric tool (4.0 or before).
+        </p>
+        <p>
+          You can <a href="https://www.gov.uk/guidance/biodiversity-metric-calculate-the-biodiversity-net-gain-of-a-project-or-development" target="_blank">find out more about completing a biodiversity metric calculation</a> on GOV.UK.
+        </p>
         <div id="location-upload-hint">
           <p>The file should be:</p>
           <ul class="govuk-list govuk-list--bullet">
@@ -30,18 +36,6 @@
               text: "Choose file",
               classes: "govuk-visually-hidden"
             }
-          }) }}
-
-          {{ govukDetails({
-            summaryText: "What to do if you have no biodiversity metric calculations",
-            text: ("
-            <p>You need to upload completed statutory biodiversity metric calculations for the 
-            biodiversity gain site you want to register.</p>
-            <p>You can <a href='https://www.gov.uk/guidance/biodiversity-metric-calculate-the-biodiversity-net-gain-of-a-project-or-development'>find out more about completing biodiversity metric calculations</a> on GOV.UK.</p>
-            <p>
-              <a class='govuk-link' href='https://www.gov.uk/call-charges'>Find out about call charges</a>
-            </p>
-            ") | safe
           }) }}
 
           {{ govukButton({

--- a/packages/webapp/src/views/land/upload-metric.html
+++ b/packages/webapp/src/views/land/upload-metric.html
@@ -38,13 +38,16 @@
             }
           }) }}
 
-          {{ govukButton({
-            text: "Upload",
-            attributes: {
-              id: "continue",
-              "data-testid": "continue"
-            }
-          }) }}
+          <div class="govuk-button-group">
+            {{ govukButton({
+              text: "Save and upload",
+              attributes: {
+                id: "continue",
+                "data-testid": "continue"
+              }
+            }) }}
+            <a class="govuk-link" href="/signout">Or save progress and come back later</a>
+          </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5359

We apply various content fixes as detailed in the ticket.

One point to note is that AC1b makes a change to the "what to do if you have no written authorisation" section of the "Upload written authorisation" page. This page is common to both combined case and land journeys. We have therefore assumed that the v4 design of the page is how we would ideally want it throughout the service and therefore we're okay with it applying to both pages, rather than splitting the page into separate versions for each journey. 