### PR TITLE
BNGP-5438: Fix match available habitats flow

### DIFF
--- a/packages/webapp/src/routes/combined-case/check-allocation-metric.js
+++ b/packages/webapp/src/routes/combined-case/check-allocation-metric.js
@@ -13,6 +13,7 @@ const handlers = {
       h,
       constants.routes.COMBINED_CASE_UPLOAD_ALLOCATION_METRIC,
       constants.routes.COMBINED_CASE_MATCH_HABITATS,
+      constants.routes.COMBINED_CASE_MATCH_ALLOCATION_SUMMARY,
       constants.views.COMBINED_CASE_CHECK_UPLOAD_ALLOCATION_METRIC,
       href
     )

--- a/packages/webapp/src/utils/helpers.js
+++ b/packages/webapp/src/utils/helpers.js
@@ -805,14 +805,20 @@ const getDeveloperCheckMetricFileContext = request => {
   }
 }
 
-const checkDeveloperUploadMetric = async (request, h, noRedirectRoute, yesRedirectRoute, viewTemplate, href) => {
+const checkDeveloperUploadMetric = async (request, h, noRedirectRoute, yesRedirectRoute, matchHabitatsCompleteRedirectRoute, viewTemplate, href) => {
   const checkUploadMetric = request.payload.checkUploadMetric
   const metricUploadLocation = request.yar.get(constants.redisKeys.DEVELOPER_METRIC_LOCATION)
   request.yar.set(constants.redisKeys.DEVELOPER_METRIC_FILE_CHECKED, checkUploadMetric)
+  const matchHabitatsComplete = request.yar.get(constants.redisKeys.COMBINED_CASE_MATCH_AVAILABLE_HABITATS_COMPLETE)
 
   if (checkUploadMetric === constants.CHECK_UPLOAD_METRIC_OPTIONS.NO) {
     return h.redirect(noRedirectRoute)
-  } else if (checkUploadMetric === constants.CHECK_UPLOAD_METRIC_OPTIONS.YES) {
+  }
+
+  if (checkUploadMetric === constants.CHECK_UPLOAD_METRIC_OPTIONS.YES) {
+    if (matchHabitatsComplete) {
+      return h.redirect(matchHabitatsCompleteRedirectRoute)
+    }
     return h.redirect(yesRedirectRoute)
   }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5438

This change addresses the issue where users are not redirected to the mini CYA (Check Your Answers) page immediately after confirming the developer metric file in the combined case journey after they have successfully matched habitats. We do this by adding a check to see if habitats are already matched and then changing the routing accordingly.