### PR TITLE
BNGP-5439: Fix add landowner organisation 500 error

### DIFF
--- a/packages/webapp/src/routes/__tests__/land/add-landowner-organisation.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/add-landowner-organisation.spec.js
@@ -82,6 +82,23 @@ describe(url, () => {
 
       expect(viewResult).toEqual(constants.routes.CHECK_LANDOWNERS)
     })
+    it('should add landowner to legal agreement and redirect to COMBINED_CASE_CHECK_LANDOWNERS page when this is a combined case request', async () => {
+      const request = {
+        yar: redisMap,
+        payload: {
+          organisationName: 'org3',
+          emailAddress: 'me@me.com'
+        },
+        query: {},
+        _route: {
+          path: '/combined-case/add-landowner-organisation'
+        }
+      }
+
+      await addLandownerOrganisations.default[1].handler(request, h)
+
+      expect(viewResult).toEqual(constants.reusedRoutes.COMBINED_CASE_CHECK_LANDOWNERS)
+    })
     it('should return an error for empty id in query string', async () => {
       const queryUrl = url + '?id='
       const response = await submitPostRequest({ url: queryUrl }, 400)

--- a/packages/webapp/src/routes/land/add-landowner-organisation.js
+++ b/packages/webapp/src/routes/land/add-landowner-organisation.js
@@ -75,7 +75,9 @@ const handlers = {
     }
     request.yar.set(constants.redisKeys.LEGAL_AGREEMENT_LANDOWNER_CONSERVATION_CONVENANTS, landownerOrganisations)
     const referrerUrl = getValidReferrerUrl(request.yar, constants.LAND_LEGAL_AGREEMENT_VALID_REFERRERS)
-    return h.redirect(referrerUrl || constants.routes.CHECK_LANDOWNERS)
+    const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
+    const checkLandownersUrl = isCombinedCase ? constants.reusedRoutes.COMBINED_CASE_CHECK_LANDOWNERS : constants.routes.CHECK_LANDOWNERS
+    return h.redirect(referrerUrl || checkLandownersUrl)
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5439

Attempting to add an additional landowner organisation for a combined case application results in a 500 error. This is due to the `POST` handler of `add-landowner-organisation` sending the user to the `land/check-landowners` route regardless of the application type. We fix this by adding a check to see if this is a combined case application and sending the user to `combined-case/check-landowners` if so.