### PR TITLE
BNGP-5443: Add service menu to error pages

### DIFF
--- a/packages/webapp/src/plugins/__tests__/error-pages.spec.js
+++ b/packages/webapp/src/plugins/__tests__/error-pages.spec.js
@@ -13,6 +13,7 @@ describe('error-pages', () => {
       url: '/sdgfdfghdfghdf'
     })
     expect(response.statusCode).toEqual(404)
+    expect(response.result).toContain('Page not found')
   })
 
   it('it handles internal error', async () => {
@@ -21,5 +22,6 @@ describe('error-pages', () => {
       url: '/error'
     })
     expect(response.statusCode).toEqual(500)
+    expect(response.result).toContain('Sorry, there is a problem with the service')
   })
 })

--- a/packages/webapp/src/plugins/error-pages.js
+++ b/packages/webapp/src/plugins/error-pages.js
@@ -3,17 +3,11 @@ import getApplicantContext from '../utils/get-applicant-context.js'
 const errorPages = {
   name: 'error-pages',
   register: server => {
-    server.ext('onPreResponse', (request, h) => {
+    server.ext('onPreResponse', async (request, h) => {
       const response = request.response
 
       if (response.isBoom) {
-        // An error was raised during
-        // processing the request
         const statusCode = response.output.statusCode
-
-        if (statusCode === 404) {
-          return h.view('404').code(statusCode)
-        }
 
         // Log the error
         request.log('error', {
@@ -22,23 +16,37 @@ const errorPages = {
           stack: response.data ? response.data.stack : response.stack
         })
 
-        // The return the `500` view
-        const { representing, organisation } = getApplicantContext(request.auth.credentials.account, request.yar)
-        const accountInfo = request.auth.credentials.account.idTokenClaims
-
         const context = {
           auth: {
-            firstName: accountInfo.firstName,
-            lastName: accountInfo.lastName
+            firstName: '',
+            lastName: ''
           }
         }
 
-        if (organisation) {
-          context.auth.representing = representing
+        // Handle 404 errors
+        if (statusCode === 404) {
+          return h.view('404', context).code(statusCode)
         }
 
+        // Handle other errors and add additional context if authenticated
+        if (request.auth?.credentials) {
+          const { representing, organisation } = getApplicantContext(request.auth.credentials.account, request.yar)
+          const accountInfo = request.auth.credentials.account.idTokenClaims
+
+          context.auth = {
+            firstName: accountInfo.firstName,
+            lastName: accountInfo.lastName
+          }
+
+          if (organisation) {
+            context.auth.representing = representing
+          }
+        }
+
+        // Return the 500 view with context
         return h.view('500', context).code(statusCode)
       }
+
       return h.continue
     })
   }

--- a/packages/webapp/src/plugins/error-pages.js
+++ b/packages/webapp/src/plugins/error-pages.js
@@ -1,3 +1,5 @@
+import getApplicantContext from '../utils/get-applicant-context.js'
+
 const errorPages = {
   name: 'error-pages',
   register: server => {
@@ -9,8 +11,6 @@ const errorPages = {
         // processing the request
         const statusCode = response.output.statusCode
 
-        // In the event of 404
-        // return the `404` view
         if (statusCode === 404) {
           return h.view('404').code(statusCode)
         }
@@ -23,7 +23,21 @@ const errorPages = {
         })
 
         // The return the `500` view
-        return h.view('500').code(statusCode)
+        const { representing, organisation } = getApplicantContext(request.auth.credentials.account, request.yar)
+        const accountInfo = request.auth.credentials.account.idTokenClaims
+
+        const context = {
+          auth: {
+            firstName: accountInfo.firstName,
+            lastName: accountInfo.lastName
+          }
+        }
+
+        if (organisation) {
+          context.auth.representing = representing
+        }
+
+        return h.view('500', context).code(statusCode)
       }
       return h.continue
     })

--- a/packages/webapp/src/plugins/error-pages.js
+++ b/packages/webapp/src/plugins/error-pages.js
@@ -35,11 +35,8 @@ const errorPages = {
 
           context.auth = {
             firstName: accountInfo.firstName,
-            lastName: accountInfo.lastName
-          }
-
-          if (organisation) {
-            context.auth.representing = representing
+            lastName: accountInfo.lastName,
+            ...(organisation && { representing })
           }
         }
 

--- a/packages/webapp/src/views/404.html
+++ b/packages/webapp/src/views/404.html
@@ -1,6 +1,5 @@
 {% extends 'layout.html' %}
 {% set pageHeading = "Page not found" %}
-{% set hideSigninNav = true %}
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/packages/webapp/src/views/500.html
+++ b/packages/webapp/src/views/500.html
@@ -1,6 +1,5 @@
 {% extends 'layout.html' %}
 {% set pageHeading = "Sorry, there is a problem with the service" %}
-{% set hideSigninNav = true %}
 {% block content %}
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5443

The generic error message pages do not allow the user to sign out or go directly to the application dashboard directly from it. We fix this by removing the `hideSigninNav` toggle from the 500 and 404 pages. We also add logic to pass the username to the 500 page and handle unauthorised 500's.