### PR TITLE
BNGP-5448: Fix metric task list state being cleared before new file uploaded

### DIFF
--- a/packages/webapp/src/journey-validation/combined-case/habitat-info.js
+++ b/packages/webapp/src/journey-validation/combined-case/habitat-info.js
@@ -46,7 +46,7 @@ const habitatInfoJourneys = [
         ...UPLOAD_METRIC.sessionKeys,
         ...CHECK_UPLOAD_METRIC.sessionKeys
       ],
-      [ANY, ANY, ANY, ANY, 'yes']
+      [ANY, ANY, ANY, ANY]
     ),
     journeyStepFromRoute(CHECK_HABITAT_BASELINE, [true]),
     journeyStepFromRoute(CHECK_HABITAT_CREATED, [true])

--- a/packages/webapp/src/journey-validation/registration/habitat-info.js
+++ b/packages/webapp/src/journey-validation/registration/habitat-info.js
@@ -46,7 +46,7 @@ const habitatInfoJourneys = [
         ...UPLOAD_METRIC.sessionKeys,
         ...CHECK_UPLOAD_METRIC.sessionKeys
       ],
-      [ANY, ANY, ANY, ANY, 'yes']
+      [ANY, ANY, ANY, ANY]
     ),
     journeyStepFromRoute(CHECK_HABITAT_BASELINE, [true]),
     journeyStepFromRoute(CHECK_HABITAT_CREATED, [true])

--- a/packages/webapp/src/journey-validation/shared/habitat-info.js
+++ b/packages/webapp/src/journey-validation/shared/habitat-info.js
@@ -16,7 +16,7 @@ const createUploadMetricRoute = (uploadRoute, checkRoute) => routeDefinition(
 
 const createCheckUploadMetricRoute = (checkRoute, uploadRoute, nextRoute) => routeDefinition(
   checkRoute,
-  [constants.redisKeys.METRIC_FILE_CHECKED],
+  [],
   (session) => {
     const checkUploadMetric = session.get(constants.redisKeys.METRIC_FILE_CHECKED)
     if (checkUploadMetric === 'no') {

--- a/packages/webapp/src/routes/__tests__/land/check-metric-file.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/check-metric-file.spec.js
@@ -80,27 +80,5 @@ describe(url, () => {
         }
       })
     })
-    it('clears any matched habitats if the user selects no', async () => {
-      postOptions.payload.checkUploadMetric = constants.confirmLandBoundaryOptions.NO
-      const sessionData = {
-        [constants.redisKeys.APPLICATION_TYPE]: constants.applicationTypes.REGISTRATION,
-        [constants.redisKeys.COMBINED_CASE_ALLOCATION_HABITATS]: {
-          habitatType: 'Sparsely vegetated land - Calaminarian grasslands',
-          condition: 'Good',
-          sheet: 'd3',
-          module: 'Enhanced',
-          state: 'Habitat',
-          id: '0',
-          size: 2,
-          measurementUnits: 'hectares',
-          rowNum: 12,
-          processed: false
-        },
-        [constants.redisKeys.COMBINED_CASE_MATCH_AVAILABLE_HABITATS_COMPLETE]: true
-      }
-      await submitPostRequest(postOptions, 302, sessionData)
-      expect(sessionData).not.toHaveProperty(constants.redisKeys.COMBINED_CASE_ALLOCATION_HABITATS)
-      expect(sessionData).not.toHaveProperty(constants.redisKeys.COMBINED_CASE_MATCH_AVAILABLE_HABITATS_COMPLETE)
-    })
   })
 })

--- a/packages/webapp/src/routes/land/check-metric-file.js
+++ b/packages/webapp/src/routes/land/check-metric-file.js
@@ -12,12 +12,6 @@ const handlers = {
     const metricUploadLocation = request.yar.get(constants.redisKeys.METRIC_LOCATION)
     request.yar.set(constants.redisKeys.METRIC_FILE_CHECKED, checkUploadMetric)
 
-    // If the metric file is changing then we clear any previously matched habitats as they're no longer valid
-    if (checkUploadMetric === constants.CHECK_UPLOAD_METRIC_OPTIONS.NO) {
-      request.yar.clear(constants.redisKeys.COMBINED_CASE_ALLOCATION_HABITATS)
-      request.yar.clear(constants.redisKeys.COMBINED_CASE_MATCH_AVAILABLE_HABITATS_COMPLETE)
-    }
-
     return getNextStep(request, h, (e) => {
       return h.view(constants.views.CHECK_UPLOAD_METRIC, {
         filename: path.basename(metricUploadLocation),

--- a/packages/webapp/src/routes/land/upload-metric.js
+++ b/packages/webapp/src/routes/land/upload-metric.js
@@ -17,6 +17,14 @@ async function processSuccessfulUpload (result, request, h) {
     await deleteBlobFromContainers(result.config.blobConfig.blobName)
     return h.view(constants.views.UPLOAD_METRIC, validationError)
   }
+
+  // Clear any previously matched combined case habitats as they're no longer valid after uploading a new file
+  const isCombinedCase = (request?._route?.path || '').startsWith('/combined-case')
+  if (isCombinedCase) {
+    request.yar.clear(constants.redisKeys.COMBINED_CASE_ALLOCATION_HABITATS)
+    request.yar.clear(constants.redisKeys.COMBINED_CASE_MATCH_AVAILABLE_HABITATS_COMPLETE)
+  }
+
   request.yar.set(constants.redisKeys.METRIC_LOCATION, result.config.blobConfig.blobName)
   request.yar.set(constants.redisKeys.METRIC_FILE_SIZE, result.fileSize)
   request.yar.set(constants.redisKeys.METRIC_FILE_TYPE, result.fileType)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5448

If a user uploads a statutory biodiversity metric file, then goes to upload a new one but returns to the task list before actually uploading it, the statuses of "Add habitat baseline, creation and enhancements" and "Match available habitats" are being reset.

We fix the first by no longer using `METRIC_FILE_CHECKED` (which is used to determine routing after a user selects "yes, the file is okay" or "no, upload a new file") as a session key to determine the status. Note that this bug was raised for combined case but it also affects the land journey, so we ensure the fix is applied here too.

We fix the second by moving the clearing of the relevant session keys to after a file is successfully uploaded.