### PR TITLE
BNGP-5442: Show error if metric validation fails on submission

### DIFF
--- a/packages/webapp/src/plugins/__tests__/error-pages.spec.js
+++ b/packages/webapp/src/plugins/__tests__/error-pages.spec.js
@@ -38,4 +38,18 @@ describe('error-pages', () => {
     expect(response.result).toContain('Your application could not be submitted')
     expect(response.result).toContain('Please check your metric file(s)')
   })
+
+  it('should continue processing for non-error responses', async () => {
+    const server = await getServer()
+
+    // Send a normal request that should not trigger the custom error handling
+    const response = await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+
+    // Check that the response is normal and no error handling is triggered
+    expect(response.statusCode).toEqual(302)
+    expect(response.result).toBeDefined()
+  })
 })

--- a/packages/webapp/src/plugins/__tests__/error-pages.spec.js
+++ b/packages/webapp/src/plugins/__tests__/error-pages.spec.js
@@ -24,4 +24,18 @@ describe('error-pages', () => {
     expect(response.statusCode).toEqual(500)
     expect(response.result).toContain('Sorry, there is a problem with the service')
   })
+
+  it('handles 500 error with referer /check-and-submit', async () => {
+    const response = await getServer().inject({
+      method: 'GET',
+      url: '/error',
+      headers: {
+        referer: '/check-and-submit'
+      }
+    })
+
+    expect(response.statusCode).toEqual(500)
+    expect(response.result).toContain('Your application could not be submitted')
+    expect(response.result).toContain('Please check your metric file(s)')
+  })
 })

--- a/packages/webapp/src/plugins/__tests__/error-pages.spec.js
+++ b/packages/webapp/src/plugins/__tests__/error-pages.spec.js
@@ -13,6 +13,7 @@ describe('error-pages', () => {
       url: '/sdgfdfghdfghdf'
     })
     expect(response.statusCode).toEqual(404)
+    expect(response.result).toContain('Page not found')
   })
 
   it('it handles internal error', async () => {
@@ -21,5 +22,6 @@ describe('error-pages', () => {
       url: '/error'
     })
     expect(response.statusCode).toEqual(500)
+    expect(response.result).toContain('Sorry, there is a problem with the service')
   })
 })

--- a/packages/webapp/src/plugins/error-pages.js
+++ b/packages/webapp/src/plugins/error-pages.js
@@ -42,7 +42,7 @@ const errorPages = {
 
         // Handle 500 errors
         const referer = request.headers.referer
-        if (statusCode === 500 && referer && referer.endsWith('/check-and-submit')) {
+        if (statusCode === 500 && referer?.endsWith('/check-and-submit')) {
           const errorContext = {
             ...context,
             metricValidationError: 'Your application could not be submitted.  This could be because of an error in a metric file that you uploaded.  Please check your metric file(s) for any data errors'

--- a/packages/webapp/src/plugins/error-pages.js
+++ b/packages/webapp/src/plugins/error-pages.js
@@ -3,17 +3,11 @@ import getApplicantContext from '../utils/get-applicant-context.js'
 const errorPages = {
   name: 'error-pages',
   register: server => {
-    server.ext('onPreResponse', (request, h) => {
+    server.ext('onPreResponse', async (request, h) => {
       const response = request.response
 
       if (response.isBoom) {
-        // An error was raised during
-        // processing the request
         const statusCode = response.output.statusCode
-
-        if (statusCode === 404) {
-          return h.view('404').code(statusCode)
-        }
 
         // Log the error
         request.log('error', {
@@ -22,23 +16,37 @@ const errorPages = {
           stack: response.data ? response.data.stack : response.stack
         })
 
-        // The return the `500` view
-        const { representing, organisation } = getApplicantContext(request.auth.credentials.account, request.yar)
-        const accountInfo = request.auth.credentials.account.idTokenClaims
-
         const context = {
           auth: {
-            firstName: accountInfo.firstName,
-            lastName: accountInfo.lastName
+            firstName: '',
+            lastName: ''
           }
         }
 
-        if (organisation) {
-          context.auth.representing = representing
+        // Handle 404 errors
+        if (statusCode === 404) {
+          return h.view('404', context).code(statusCode)
         }
 
+        // Handle other errors and add additional context if authenticated
+        if (request.auth?.credentials) {
+          const { representing, organisation } = getApplicantContext(request.auth.credentials.account, request.yar)
+          const accountInfo = request.auth.credentials.account.idTokenClaims
+
+          context.auth = {
+            firstName: accountInfo.firstName,
+            lastName: accountInfo.lastName
+          }
+
+          if (organisation) {
+            context.auth.representing = representing
+          }
+        }
+
+        // Return the 500 view with context
         return h.view('500', context).code(statusCode)
       }
+
       return h.continue
     })
   }

--- a/packages/webapp/src/plugins/error-pages.js
+++ b/packages/webapp/src/plugins/error-pages.js
@@ -28,7 +28,7 @@ const errorPages = {
           return h.view('404', context).code(statusCode)
         }
 
-        // Handle other errors and add additional context if authenticated
+        // Add additional context if authenticated
         if (request.auth?.credentials) {
           const { representing, organisation } = getApplicantContext(request.auth.credentials.account, request.yar)
           const accountInfo = request.auth.credentials.account.idTokenClaims
@@ -40,7 +40,17 @@ const errorPages = {
           }
         }
 
-        // Return the 500 view with context
+        // Handle 500 errors
+        const referer = request.headers.referer
+        if (statusCode === 500 && referer && referer.endsWith('/check-and-submit')) {
+          const errorContext = {
+            ...context,
+            metricValidationError: 'Your application could not be submitted.  This could be because of an error in a metric file that you uploaded.  Please check your metric file(s) for any data errors'
+          }
+          return h.view('500', errorContext).code(statusCode)
+        }
+
+        // Return the generic 500 view
         return h.view('500', context).code(statusCode)
       }
 

--- a/packages/webapp/src/plugins/error-pages.js
+++ b/packages/webapp/src/plugins/error-pages.js
@@ -1,3 +1,5 @@
+import getApplicantContext from '../utils/get-applicant-context.js'
+
 const errorPages = {
   name: 'error-pages',
   register: server => {
@@ -9,8 +11,6 @@ const errorPages = {
         // processing the request
         const statusCode = response.output.statusCode
 
-        // In the event of 404
-        // return the `404` view
         if (statusCode === 404) {
           return h.view('404').code(statusCode)
         }
@@ -23,7 +23,21 @@ const errorPages = {
         })
 
         // The return the `500` view
-        return h.view('500').code(statusCode)
+        const { representing, organisation } = getApplicantContext(request.auth.credentials.account, request.yar)
+        const accountInfo = request.auth.credentials.account.idTokenClaims
+
+        const context = {
+          auth: {
+            firstName: accountInfo.firstName,
+            lastName: accountInfo.lastName
+          }
+        }
+
+        if (organisation) {
+          context.auth.representing = representing
+        }
+
+        return h.view('500', context).code(statusCode)
       }
       return h.continue
     })

--- a/packages/webapp/src/plugins/error-pages.js
+++ b/packages/webapp/src/plugins/error-pages.js
@@ -35,11 +35,8 @@ const errorPages = {
 
           context.auth = {
             firstName: accountInfo.firstName,
-            lastName: accountInfo.lastName
-          }
-
-          if (organisation) {
-            context.auth.representing = representing
+            lastName: accountInfo.lastName,
+            ...(organisation && { representing })
           }
         }
 

--- a/packages/webapp/src/views/404.html
+++ b/packages/webapp/src/views/404.html
@@ -1,6 +1,5 @@
 {% extends 'layout.html' %}
 {% set pageHeading = "Page not found" %}
-{% set hideSigninNav = true %}
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/packages/webapp/src/views/500.html
+++ b/packages/webapp/src/views/500.html
@@ -6,7 +6,11 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-xl">{{ pageHeading }}</h1>
-          <p class="govuk-body">Try again later.</p>
+          {% if metricValidationError %}
+            <p class="govuk-body">{{ metricValidationError }}</p>
+          {% else %}  
+            <p class="govuk-body">Try again later.</p>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/packages/webapp/src/views/500.html
+++ b/packages/webapp/src/views/500.html
@@ -1,6 +1,5 @@
 {% extends 'layout.html' %}
 {% set pageHeading = "Sorry, there is a problem with the service" %}
-{% set hideSigninNav = true %}
 {% block content %}
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5442

Currently, when a user submits an application with a metric error, a generic 500 error page is displayed. This doesn't inform the user of the actual issue. To improve the user experience, we need to display a clear error message indicating that the metric file has an error and prompting the user to fix and re-upload the file.