### PR TITLE
BNGP-5467: Fix `DAC_Headings_01`

### DIFF
--- a/packages/webapp/src/views/common/check-defra-account-details.html
+++ b/packages/webapp/src/views/common/check-defra-account-details.html
@@ -24,7 +24,7 @@
         fieldset: {
           legend: {
             text: "Confirm your Defra account details are up to date",
-            isPageHeading: true,
+            isPageHeading: false,
             classes: "govuk-fieldset__legend--m"
           }
         },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5467

This change fixes the issue raised in the Accessibility report: DAC_Headings_01 where we have an unwanted h1 tag in a fieldset. We fix it by changing the `isPageHeading` from `true` to `false`