### PR TITLE
BNGP-5476: Fix other landowners flow

### DIFF
--- a/packages/webapp/src/journey-validation/combined-case/legal-agreement.js
+++ b/packages/webapp/src/journey-validation/combined-case/legal-agreement.js
@@ -88,7 +88,7 @@ const CHECK_RESPONSIBLE_BODIES = checkResponsibleBodiesRoute(
 const OTHER_LANDOWNERS = otherLandownersRoute(
   constants.reusedRoutes.COMBINED_CASE_ANY_OTHER_LANDOWNERS,
   constants.reusedRoutes.COMBINED_CASE_LANDOWNER_INDIVIDUAL_ORGANISATION,
-  constants.reusedRoutes.COMBINED_CASE_HABITAT_PLAN_LEGAL_AGREEMENT
+  constants.reusedRoutes.COMBINED_CASE_CHECK_LEGAL_AGREEMENT_DETAILS
 )
 
 // // land/landowner-conservation-covenant-individual-organisation

--- a/packages/webapp/src/journey-validation/registration/legal-agreement.js
+++ b/packages/webapp/src/journey-validation/registration/legal-agreement.js
@@ -81,7 +81,7 @@ const CHECK_RESPONSIBLE_BODIES = checkResponsibleBodiesRoute(
 const OTHER_LANDOWNERS = otherLandownersRoute(
   constants.routes.ANY_OTHER_LANDOWNERS,
   constants.routes.LANDOWNER_INDIVIDUAL_ORGANISATION,
-  constants.routes.HABITAT_PLAN_LEGAL_AGREEMENT
+  constants.routes.CHECK_LEGAL_AGREEMENT_DETAILS
 )
 
 // // land/landowner-conservation-covenant-individual-organisation

--- a/packages/webapp/src/journey-validation/shared/legal-agreement.js
+++ b/packages/webapp/src/journey-validation/shared/legal-agreement.js
@@ -108,7 +108,11 @@ const otherLandownersRoute = (startUrl, nextUrl, altNextUrl) => routeDefinition(
       return nextUrl
     } else if (anyOtherLOValue === 'no') {
       session.set(constants.redisKeys.LEGAL_AGREEMENT_LANDOWNER_CONSERVATION_CONVENANTS, null)
-      return altNextUrl
+      const referrerUrl = getValidReferrerUrl(session, [
+        ...constants.LAND_LEGAL_AGREEMENT_VALID_REFERRERS,
+        ...constants.COMBINED_CASE_LEGAL_AGREEMENT_VALID_REFERRERS
+      ])
+      return referrerUrl || altNextUrl
     } else {
       const message = 'Select yes if there are any other landowners or leaseholders'
       const href = '#anyOtherLO-yes'

--- a/packages/webapp/src/routes/__tests__/land/any-other-landowners.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/any-other-landowners.spec.js
@@ -30,7 +30,7 @@ describe(url, () => {
     it('Should continue journey to HABITAT_PLAN_LEGAL_AGREEMENT if no is chosen', async () => {
       postOptions.payload.anyOtherLOValue = 'no'
       const res = await submitPostRequest(postOptions, 302, sessionData)
-      expect(res.headers.location).toEqual(constants.routes.HABITAT_PLAN_LEGAL_AGREEMENT)
+      expect(res.headers.location).toEqual(constants.routes.CHECK_LEGAL_AGREEMENT_DETAILS)
     })
 
     it('Should fail journey if no answer', async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5476

This change fixes the flow of the `any other landowners` section in the `legal agreement` section. It fixes for both registration and combined case journeys by updating the `altNextUrl` path in the journey validation.