### PR TITLE
BNGP-5506: Last updated time is an hour out

### DIFF
--- a/packages/webapp/src/utils/helpers.js
+++ b/packages/webapp/src/utils/helpers.js
@@ -107,8 +107,16 @@ const validateAndParseISOString = isoString => {
 }
 
 const getFormattedDateTime = dateString => {
-  const date = moment.utc(dateString)
-  return date.isValid() && date.format('D MMMM YYYY, h:mma')
+  const date = new Date(dateString)
+  return date.toLocaleString('en-GB', {
+    timeZone: 'Europe/London',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: true
+  })
 }
 
 const formatDateBefore = (isoString, format = 'D MMMM YYYY') => moment.utc(isoString).subtract(1, 'day').format(format)


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5506

This change fixes the issue of the last updated time for applications being displayed an hour off. The issue was caused by the `getFormattedDateTime` function using UTC time. We've fixed it by updating the helper function to use the built-in JavaScript `toLocaleString` method instead of moment.