### PR TITLE
BNGP-5512: Duplicate file upload results in missing file

### DIFF
--- a/packages/webapp/src/routes/__tests__/combined-case/upload-local-land-charge.spec.js
+++ b/packages/webapp/src/routes/__tests__/combined-case/upload-local-land-charge.spec.js
@@ -35,7 +35,7 @@ describe('Local Land Charge upload controller tests', () => {
     it('should upload local land charge document to cloud storage', (done) => {
       jest.isolateModules(async () => {
         try {
-          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainers')
+          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainersWithCheck')
           const uploadConfig = Object.assign({}, baseConfig)
           uploadConfig.hasError = false
           uploadConfig.filePath = `${mockDataPath}/local-land-charge.pdf`

--- a/packages/webapp/src/routes/__tests__/land/upload-habitat-plan.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-habitat-plan.spec.js
@@ -28,7 +28,7 @@ describe('Habitat Plan upload controller tests', () => {
     it('should upload habitat plan document to cloud storage and delete previous upload', (done) => {
       jest.isolateModules(async () => {
         try {
-          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainers')
+          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainersWithCheck')
           const uploadConfig = Object.assign({}, baseConfig)
           uploadConfig.headers = {
             referer: `http://localhost:3000${url}`

--- a/packages/webapp/src/routes/__tests__/land/upload-land-boundary.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-land-boundary.spec.js
@@ -36,7 +36,7 @@ describe('Land boundary upload controller tests', () => {
       jest.isolateModules(async () => {
         try {
           jest.mock('../../../utils/azure-storage.js')
-          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainers')
+          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainersWithCheck')
           const uploadConfig = Object.assign({}, baseConfig)
           uploadConfig.hasError = false
           uploadConfig.filePath = `${mockDataPath}/legal-agreement.pdf`

--- a/packages/webapp/src/routes/__tests__/land/upload-local-land-charge.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-local-land-charge.spec.js
@@ -35,7 +35,7 @@ describe('Local Land Charge upload controller tests', () => {
     it('should upload local land charge document to cloud storage', (done) => {
       jest.isolateModules(async () => {
         try {
-          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainers')
+          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainersWithCheck')
           const uploadConfig = Object.assign({}, baseConfig)
           uploadConfig.hasError = false
           uploadConfig.filePath = `${mockDataPath}/local-land-charge.pdf`

--- a/packages/webapp/src/routes/__tests__/land/upload-metric.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-metric.spec.js
@@ -39,7 +39,7 @@ describe('Metric file upload controller tests', () => {
     it('should upload metric file to cloud storage', (done) => {
       jest.isolateModules(async () => {
         try {
-          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainers')
+          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainersWithCheck')
           const uploadConfig = getBaseConfig()
           uploadConfig.hasError = false
           uploadConfig.filePath = `${mockDataPath}/metric-file-4.1.xlsm`
@@ -61,7 +61,7 @@ describe('Metric file upload controller tests', () => {
     it('should upload feb24 format metric file to cloud storage', (done) => {
       jest.isolateModules(async () => {
         try {
-          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainers')
+          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainersWithCheck')
           const uploadConfig = getBaseConfig()
           uploadConfig.hasError = false
           uploadConfig.filePath = `${mockDataPath}/metric-file-4.1-feb24.xlsm`
@@ -247,7 +247,7 @@ describe('Metric file upload controller tests', () => {
           config.sessionData[`${constants.redisKeys.APPLICATION_TYPE}`] = constants.applicationTypes.REGISTRATION
           const response = await uploadFile(config)
           expect(response.result).toContain('The selected file must use the statutory biodiversity metric')
-          expect(spy).toHaveBeenCalledTimes(2)
+          expect(spy).toHaveBeenCalledTimes(1)
           setImmediate(() => {
             done()
           })
@@ -273,7 +273,7 @@ describe('Metric file upload controller tests', () => {
           config.sessionData[`${constants.redisKeys.APPLICATION_TYPE}`] = constants.applicationTypes.REGISTRATION
           const response = await uploadFile(config)
           expect(response.result).toContain('The selected file does not have enough data')
-          expect(spy).toHaveBeenCalledTimes(2)
+          expect(spy).toHaveBeenCalledTimes(1)
           setImmediate(() => {
             done()
           })
@@ -299,7 +299,7 @@ describe('Metric file upload controller tests', () => {
           config.sessionData[`${constants.redisKeys.APPLICATION_TYPE}`] = constants.applicationTypes.REGISTRATION
           const response = await uploadFile(config)
           expect(response.result).toContain('The selected file must not be a draft version')
-          expect(spy).toHaveBeenCalledTimes(2)
+          expect(spy).toHaveBeenCalledTimes(1)
           setImmediate(() => {
             done()
           })

--- a/packages/webapp/src/routes/__tests__/land/upload-written-authorisation.spec.js
+++ b/packages/webapp/src/routes/__tests__/land/upload-written-authorisation.spec.js
@@ -32,7 +32,7 @@ describe('Proof of ownership upload controller tests', () => {
     it('should upload written authorisation document to cloud storage', (done) => {
       jest.isolateModules(async () => {
         try {
-          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainers')
+          const spy = jest.spyOn(azureStorage, 'deleteBlobFromContainersWithCheck')
           const uploadConfig = Object.assign({}, baseConfig)
           uploadConfig.headers = {
             referer: 'http://localhost:30000/land/check-written-authorisation-file'

--- a/packages/webapp/src/routes/land/upload-habitat-plan.js
+++ b/packages/webapp/src/routes/land/upload-habitat-plan.js
@@ -3,14 +3,16 @@ import constants from '../../utils/constants.js'
 import { uploadFile } from '../../utils/upload.js'
 import { generatePayloadOptions } from '../../utils/generate-payload-options.js'
 import { processErrorUpload } from '../../utils/upload-error-handler.js'
-import { deleteBlobFromContainers } from '../../utils/azure-storage.js'
+import { deleteBlobFromContainersWithCheck } from '../../utils/azure-storage.js'
 import { getNextStep } from '../../journey-validation/task-list-generator.js'
 
 const HABITAT_PLAN_ID = '#uploadHabitatPlan'
 
 async function processSuccessfulUpload (result, request, h) {
-  await deleteBlobFromContainers(request.yar.get(constants.redisKeys.HABITAT_PLAN_LOCATION, true))
-  request.yar.set(constants.redisKeys.HABITAT_PLAN_LOCATION, result.config.blobConfig.blobName)
+  const blobPath = result.config.blobConfig.blobName
+  const previousBlobPath = request.yar.get(constants.redisKeys.HABITAT_PLAN_LOCATION, true)
+  await deleteBlobFromContainersWithCheck(blobPath, previousBlobPath)
+  request.yar.set(constants.redisKeys.HABITAT_PLAN_LOCATION, blobPath)
   request.yar.set(constants.redisKeys.HABITAT_PLAN_FILE_SIZE, result.fileSize)
   request.yar.set(constants.redisKeys.HABITAT_PLAN_FILE_TYPE, result.fileType)
   request.logger.info(`${new Date().toUTCString()} Received legal and search data for ${result.config.blobConfig.blobName.substring(result.config.blobConfig.blobName.lastIndexOf('/') + 1)}`)

--- a/packages/webapp/src/routes/land/upload-local-land-charge.js
+++ b/packages/webapp/src/routes/land/upload-local-land-charge.js
@@ -3,14 +3,16 @@ import constants from '../../utils/constants.js'
 import { uploadFile } from '../../utils/upload.js'
 import { generatePayloadOptions } from '../../utils/generate-payload-options.js'
 import { processErrorUpload } from '../../utils/upload-error-handler.js'
-import { deleteBlobFromContainers } from '../../utils/azure-storage.js'
+import { deleteBlobFromContainersWithCheck } from '../../utils/azure-storage.js'
 import { getNextStep } from '../../journey-validation/task-list-generator.js'
 
 const LOCAL_LAND_CHARGE_ID = '#localLandCharge'
 
 async function processSuccessfulUpload (result, request, h) {
-  await deleteBlobFromContainers(request.yar.get(constants.redisKeys.LOCAL_LAND_CHARGE_LOCATION, true))
-  request.yar.set(constants.redisKeys.LOCAL_LAND_CHARGE_LOCATION, result.config.blobConfig.blobName)
+  const blobPath = result.config.blobConfig.blobName
+  const previousBlobPath = request.yar.get(constants.redisKeys.LOCAL_LAND_CHARGE_LOCATION, true)
+  await deleteBlobFromContainersWithCheck(blobPath, previousBlobPath)
+  request.yar.set(constants.redisKeys.LOCAL_LAND_CHARGE_LOCATION, blobPath)
   request.yar.set(constants.redisKeys.LOCAL_LAND_CHARGE_FILE_SIZE, result.fileSize)
   request.yar.set(constants.redisKeys.LOCAL_LAND_CHARGE_FILE_TYPE, result.fileType)
   request.logger.info(`${new Date().toUTCString()} Received legal and search data for ${result.config.blobConfig.blobName.substring(result.config.blobConfig.blobName.lastIndexOf('/') + 1)}`)

--- a/packages/webapp/src/routes/land/upload-ownership-proof.js
+++ b/packages/webapp/src/routes/land/upload-ownership-proof.js
@@ -13,7 +13,7 @@ const LAND_OWNERSHIP_ID = '#landOwnership'
 async function processSuccessfulUpload (result, request, h) {
   const tempFile = request.yar.get(constants.redisKeys.TEMP_LAND_OWNERSHIP_PROOF)
   if (tempFile && !tempFile.confirmed) {
-    await deleteBlobFromContainersWithCheck(tempFile.fileLocation)
+    await deleteBlobFromContainersWithCheck(result.config.blobConfig.blobName, tempFile.fileLocation)
   }
   const tempFileDetails = {
     id: generateUniqueId(),

--- a/packages/webapp/src/routes/land/upload-ownership-proof.js
+++ b/packages/webapp/src/routes/land/upload-ownership-proof.js
@@ -4,7 +4,7 @@ import { uploadFile } from '../../utils/upload.js'
 import { generatePayloadOptions } from '../../utils/generate-payload-options.js'
 import { processErrorUpload } from '../../utils/upload-error-handler.js'
 import { generateUniqueId } from '../../utils/helpers.js'
-import { deleteBlobFromContainers } from '../../utils/azure-storage.js'
+import { deleteBlobFromContainersWithCheck } from '../../utils/azure-storage.js'
 import path from 'path'
 import { getNextStep } from '../../journey-validation/task-list-generator.js'
 
@@ -13,7 +13,7 @@ const LAND_OWNERSHIP_ID = '#landOwnership'
 async function processSuccessfulUpload (result, request, h) {
   const tempFile = request.yar.get(constants.redisKeys.TEMP_LAND_OWNERSHIP_PROOF)
   if (tempFile && !tempFile.confirmed) {
-    await deleteBlobFromContainers(tempFile.fileLocation)
+    await deleteBlobFromContainersWithCheck(tempFile.fileLocation)
   }
   const tempFileDetails = {
     id: generateUniqueId(),

--- a/packages/webapp/src/utils/azure-storage.js
+++ b/packages/webapp/src/utils/azure-storage.js
@@ -47,10 +47,20 @@ const uploadStreamAndAwaitScan = async (logger, config, stream, maxAttempts = 20
 }
 
 const deleteBlobFromContainers = async blobName => {
+  console.log(`${new Date().toUTCString()} ${blobName} is about to be deleted`)
   await blobStorageConnector.deleteBlobIfExists({
     containerName: constants.BLOB_STORAGE_CONTAINER,
     blobName
   })
+  console.log(`${new Date().toUTCString()} ${blobName} has been deleted`)
 }
 
-export { uploadStreamAndAwaitScan, deleteBlobFromContainers }
+const deleteBlobFromContainersWithCheck = async (blobPath, previousBlobPath) => {
+  console.log(`${new Date().toUTCString()} ${blobPath} is about to be checked for deletion`)
+  if (blobPath !== previousBlobPath) {
+    console.log(`${new Date().toUTCString()} ${blobPath} has been passed to deleteBlobFromContainers`)
+    await deleteBlobFromContainers(previousBlobPath)
+  }
+}
+
+export { uploadStreamAndAwaitScan, deleteBlobFromContainers, deleteBlobFromContainersWithCheck }

--- a/packages/webapp/src/utils/azure-storage.js
+++ b/packages/webapp/src/utils/azure-storage.js
@@ -47,18 +47,14 @@ const uploadStreamAndAwaitScan = async (logger, config, stream, maxAttempts = 20
 }
 
 const deleteBlobFromContainers = async blobName => {
-  console.log(`${new Date().toUTCString()} ${blobName} is about to be deleted`)
   await blobStorageConnector.deleteBlobIfExists({
     containerName: constants.BLOB_STORAGE_CONTAINER,
     blobName
   })
-  console.log(`${new Date().toUTCString()} ${blobName} has been deleted`)
 }
 
 const deleteBlobFromContainersWithCheck = async (blobPath, previousBlobPath) => {
-  console.log(`${new Date().toUTCString()} ${blobPath} is about to be checked for deletion`)
   if (blobPath !== previousBlobPath) {
-    console.log(`${new Date().toUTCString()} ${blobPath} has been passed to deleteBlobFromContainers`)
     await deleteBlobFromContainers(previousBlobPath)
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/BNGP-5512

Uploading a file with the same name multiple times causes the file to be unavailable for download from the payload and browser page. The bug affects most upload pages on the registration (and therefore the combined case) journeys. 
We fix the bug by writing a new `deleteBlobFromContainersWithCheck` function. This new function ensures that blobs are only deleted if they are different from the current blob, preventing unnecessary deletions.


### Utility Function Update:
* Introduced `deleteBlobFromContainersWithCheck` in `azure-storage.js`:
  * Added the new function to ensure blobs are only deleted if they are different from the current blob.

### Route Handlers Update:
* Updated route handler files to use `deleteBlobFromContainersWithCheck`:
  * `upload-habitat-plan.js`
  * `upload-land-boundary.js`
  * `upload-local-land-charge.js`
  * `upload-metric.js`
  * `upload-ownership-proof.js`
  * `upload-written-authorisation.js`